### PR TITLE
fix non-null assertation and optional chaining

### DIFF
--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -16,8 +16,6 @@ export default function PopupReview(prop) {
   }
   const [defaultReviewAnswers] = useQuery(getReviewAnswers, reviewAnswerQueryParams)
   const [reviewAnswers, setReviewAnswers] = useState(defaultReviewAnswers)
-
-  console.log(reviewAnswers.find((e) => e.questionId === reviewQuestions[0]?.questionId))
   const handleSubmit = () => {
     undefined
   }
@@ -41,7 +39,7 @@ export default function PopupReview(prop) {
               key={question.questionId}
               question={question}
               currentAnswer={Number.parseInt(
-                reviewAnswers.find((e) => e.questionId === question.questionId)!.response
+                reviewAnswers.find((e) => e?.questionId === question?.questionId)!?.response
               )}
             />
           )


### PR DESCRIPTION
The cause of the error was looking for an undefined property of the review answers map. Fixed with combining the non-null assertation (`!`) and the optional chaining operator (`?`).