### PR TITLE
Update schema for handles, display names, and anonymity

### DIFF
--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -111,7 +111,7 @@ model ReviewAnswers {
   question      ReviewQuestions @relation(fields: [questionId], references: [questionId])
   response      Int
   questionId    Int
-  isAnonymous   Boolean @default(false)
+  isAnonymous   Boolean         @default(false)
 
   @@unique([articleId, questionId, userId])
 }


### PR DESCRIPTION
This PR updates the schema to include handles, display names to the user table. Display names are optional strings. If they are left blank, user handles will appear.

Also, I'm adding a function to make reviews "anonymous" at a surface level. Users can decide if they want to remain anonymous when submitting a review. To achieve this, I'm adding a boolean field `isAnonymous` in the `ReviewAnswers` table.