### PR TITLE
remove current user prop to header component

### DIFF
--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -45,7 +45,7 @@ const Home: BlitzPage = () => {
   return (
     <div className="flex flex-col min-h-screen">
       <Suspense fallback="Loading..." >
-        <Header currentUser />
+        <Header />
       </Suspense>
       <main
         className="flex-grow"


### PR DESCRIPTION
A small bug fix to remove the `currentUser` prop to the `Header` component. This error came out when building a Heroku app.
```
remote: ./app/pages/index.tsx:48:17
remote: Type error: Type '{ currentUser: true; }' is not assignable to type 'IntrinsicAttributes'.
remote:   Property 'currentUser' does not exist on type 'IntrinsicAttributes'.
remote: 
remote:   46 |     <div className="flex flex-col min-h-screen">
remote:   47 |       <Suspense fallback="Loading..." >
remote: > 48 |         <Header currentUser />
remote:      |                 ^
remote:   49 |       </Suspense>
remote:   50 |       <main
```
