### PR TITLE
Set Fira Sans as the default typeface

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
   darkMode: "media", // or 'media' or 'class'
   theme: {
     extend: {},
+    fontFamily: {
+      sans: ['"Fira Sans"', "sans-serif"],
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
This PR sets [Fira Sans](https://github.com/mozilla/Fira) as the default typeface. Fixes #179.

