### PR TITLE
Allow adding papers without a journal

### DIFF
--- a/app/mutations/addArticle.tsx
+++ b/app/mutations/addArticle.tsx
@@ -12,7 +12,7 @@ const AddArticle = z.object({
   title: z.string(),
   doi: z.string(),
   publishedYear: z.number().int(),
-  journal: z.string(),
+  journal: z.string().optional(),
   addedById: z.number().int(),
   authorString: z.string(),
 })

--- a/db/migrations/20220802230410_allow_optional_journal_names/migration.sql
+++ b/db/migrations/20220802230410_allow_optional_journal_names/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ALTER COLUMN "journal" DROP NOT NULL;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -82,7 +82,7 @@ model Article {
   doi           String           @unique
   title         String
   publishedYear Int
-  journal       String
+  journal       String?
   authorString  String
   author        Author[]
   review        ReviewAnswers[]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
   darkMode: "media", // or 'media' or 'class'
   theme: {
     extend: {},
+    fontFamily: {
+      sans: ['"Fira Sans"', "sans-serif"],
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
This PR allows adding papers without a journal. This change will allow submissions from websites like PsyArxiv, where the CrossRef record for the journal field is blank. Fixes #197.