### PR TITLE
Add space in between review summaries

### DIFF
--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -67,7 +67,7 @@ export const Review = (props) => {
         </div>
       </div>
       <div id="expand"
-        className="mt-0 w-full h-4 bg-gray-medium hover:cursor-pointer"
+        className="mt-0 w-full h-4 mb-6 bg-gray-medium hover:cursor-pointer"
         onClick={undefined}>
         <div className="mt-1 w-10 h-2 rounded-xl bg-gray-darkest m-auto"></div>
       </div>


### PR DESCRIPTION
This PR adds a space in between the review summaries. Fixes #245
![localhost_3000_articles_0ffe1981-bef1-4346-829f-1053b9f2af8b(iPhone XR) (3)](https://user-images.githubusercontent.com/42837484/184554114-75678760-1b3e-497b-bc87-e492d53eb3cd.png)
 