### PR TITLE
Render edit button to own review on the article page

### DIFF
--- a/app/core/components/ArticleAction.tsx
+++ b/app/core/components/ArticleAction.tsx
@@ -68,7 +68,7 @@ export const ArticleAction = (props) => {
   return (
     <>
       <IconButton onClick={handleClick}>
-        <MoreHoriz />
+        <MoreHoriz className="text-gray-dark dark:text-gray-medium" />
       </IconButton>
       <Menu
         id="action-menu"

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -3,10 +3,11 @@ import React, { useState } from "react"
 import { Icon } from "@iconify/react"
 import { useRouter } from "blitz"
 import StarIcon from "@mui/icons-material/Star"
+import { ArticleAction } from "./ArticleAction"
 
 
 export const Review = (props) => {
-  const { displayName, handle, reviews, userIcon, questionCategories, comment, ratingScaleMax } = props
+  const { displayName, handle, reviews, userIcon, questionCategories, comment, ratingScaleMax, showArticleAction = false, article } = props
   const submittedAt = reviews[0]?.createdAt?.toISOString().split("T")[0]
   const updatedAt = reviews[0]?.updatedAt.toISOString().split("T")[0]
   const isAnonymous = reviews[0]?.isAnonymous
@@ -25,7 +26,11 @@ export const Review = (props) => {
 
   return (
     <>
-      <div id="review-summary" className="w-full h-32 p-2 flex flex-row items-center bg-gray-light dark:bg-gray-light/10  border-black">
+      <div id="review-summary" className="relative w-full h-32 p-2 flex flex-row items-center bg-gray-light dark:bg-gray-light/10  border-black">
+        {showArticleAction &&
+          <div className="absolute top-0 right-0">
+            <ArticleAction article={article} />
+          </div>}
         <div id="review-header-section" className="flex flex-row items-center">
           <div id="avatar" className="m-2">
             <Tooltip title={tooltipText} placement="top" arrow>

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -21,6 +21,7 @@ export const ReviewList = (prop) => {
     <>
       <div id="reviews-container" className="max-w-4xl">
         {currentUserHasReview && (
+          // Show the current user's review
           <div id="your-rating-wrapper" className="mt-6 mb-6">
             <div className="border-b m-6 text-2xl text-gray-darkest dark:text-white">
               <h1>Your review</h1>
@@ -35,6 +36,8 @@ export const ReviewList = (prop) => {
                 questionCategories={questionCategories}
                 comment={currentUserReview?.reviewComments[0]?.comment}
                 ratingScaleMax={ratingScaleMax}
+                showArticleAction={true}
+                article={{ ...article, review: { ...currentUserReview?.review } }}
               />
             </div>
           </div>


### PR DESCRIPTION
This PR renders the edit button (...) on the own review on the article page, so that users can edit their rating on the spot. 

Fixes #241.