### PR TITLE
Recolor algolia search bar

### DIFF
--- a/app/core/components/SearchResultArticle.tsx
+++ b/app/core/components/SearchResultArticle.tsx
@@ -2,10 +2,7 @@ const SearchResultArticle = ({ item, components }) => {
   return (
     <>
       <div className="my-1 mx-1 flex-col">
-        <div className="mr-2">
-          {item.title}
-          <components.Highlight hit={item} attribute="name" />
-        </div>
+        <div className="mr-2">{item.title}</div>
         <div>
           <p className="text-xs text-gray-500 dark:text-gray-400">
             {item?.authors} {item.publishedYear && `(${item.publishedYear})`}

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -64,6 +64,10 @@
 :root {
   /* Search results BG = Black */
   --aa-background-color-rgb: 46, 44, 44;
+  --aa-primary-color-rgb: 148, 236, 1;
+  /* Search results selected highlight color */
+  --aa-selected-color-rgb: 148, 236, 1;
+  --aa-description-highlight-background-color-rgb: 148, 236, 1;
 }
 .aa-Panel {
   --aa-text-color-rgb: 255, 255, 255;
@@ -74,8 +78,9 @@
   :root {
     /* Search Results BG = White */
     --aa-background-color-rgb: 255, 255, 255;
-    /* Selected color */
-    --aa-selected-color-rgb: 148, 236, 1; /* green */
+    --aa-primary-color-rgb: 148, 236, 1;
+    /* Search results selected highlight color */
+    --aa-selected-color-rgb: 148, 236, 1;
     --aa-description-highlight-background-color-rgb: 148, 236, 1;
   }
   .aa-Panel {


### PR DESCRIPTION
This PR changes the color of the highlight when a search result is hovered.

This PR also removes the components hit. 

![image](https://user-images.githubusercontent.com/42837484/185753436-1cfb50cb-d58a-489d-87b1-7423947d9209.png)

![image](https://user-images.githubusercontent.com/42837484/185753454-a0858646-a3f4-4441-ad7f-35570b064fec.png)

Fixes #242 
