### PR TITLE
Allow toggle through the question categories on the all reviews page

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -5,7 +5,43 @@ import { Rating } from "@mui/material"
 import StarIcon from "@mui/icons-material/Star"
 
 export default function Article(props) {
-  const { id, authorString, doi, title, publishedYear, ratingTotal, ratingRQ, ratingDesign, ratingFindings, ratingInterpretation, ratingSignificance, ratingsCount } = props
+  const {
+    id,
+    authorString,
+    doi,
+    title,
+    publishedYear,
+    ratingTotal,
+    ratingRQ,
+    ratingDesign,
+    ratingFindings,
+    ratingInterpretation,
+    ratingSignificance,
+    ratingsCount,
+    questionCategory,
+  } = props
+
+  var selectedRating
+  switch (questionCategory) {
+    case "Overall":
+      selectedRating = ratingTotal
+      break
+    case "Research Question":
+      selectedRating = ratingRQ
+      break
+    case "Design":
+      selectedRating = ratingDesign
+      break
+    case "Findings":
+      selectedRating = ratingFindings
+      break
+    case "Interpretation":
+      selectedRating = ratingInterpretation
+      break
+    case "Significance":
+      selectedRating = ratingSignificance
+      break
+  }
 
   const ratingScaleMax = 5
   const publishedYearString = `(${publishedYear})`

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -68,7 +68,7 @@ export default function Article(props) {
         {/* Show the rating and the star */}
         <div id="with-rating-total">
           <div className="flex flex-row items-end">
-            <div className="text-5xl font-bold text-white">{selectedRating?.toFixed(1)}</div>
+            <div className="text-5xl font-bold text-white w-16">{selectedRating?.toFixed(1)}</div>
             <Rating
               readOnly
               value={selectedRating / ratingScaleMax}

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -46,6 +46,14 @@ export default function Article(props) {
   const ratingScaleMax = 5
   const publishedYearString = `(${publishedYear})`
 
+  // handle darkmode
+  const [isDark, setIsDark] = useState(false)
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    setIsDark(mediaQuery.matches)
+  }, [])
+  const smallStarColor = isDark ? "#d9d9d9" : "#737373"
+
   return (
     <div
       className="mx-6 my-2 p-2 bg-transparent border-gray-medium border-2

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -49,8 +49,8 @@ export default function Article(props) {
         <div id="author-doi-container" className="flex flex-col items-end">
           <div className="text-[0.9rem] text-gray-light">
             <FaCrown className="inline mr-2" />
-            {authorString.length < 20 ? authorString :
-              authorString.slice(0, 20) + "..."} {publishedYear && publishedYearString}
+            {authorString.length < 20 ? authorString : authorString.slice(0, 20) + "..."}{" "}
+            {publishedYear && publishedYearString}
           </div>
           <div className="text-[0.8rem] text-green-dark/60 underline whitespace-nowrap">
             <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { FaBarcode, FaCrown, FaUsers } from "react-icons/fa"
 import { Link } from "next/link"
 import { Rating } from "@mui/material"
@@ -62,25 +62,23 @@ export default function Article(props) {
       <div id="title-star-container" className="w-full flex md:flex-row flex-row justify-between">
         <div id="title" className="font-semibold inline mr-3">
           <Link href={`/articles/${id}`}>
-            {title.length < 70 ? title :
-              title.slice(0, 70) + "..."}
+            {title.length < 70 ? title : title.slice(0, 70) + "..."}
           </Link>
         </div>
+        {/* Show the rating and the star */}
         <div id="with-rating-total">
           <div className="flex flex-row items-end">
-            <div className="text-5xl font-bold text-white">
-              {ratingTotal?.toFixed(1)}
-            </div>
+            <div className="text-5xl font-bold text-white">{selectedRating?.toFixed(1)}</div>
             <Rating
               readOnly
-              value={ratingTotal / ratingScaleMax}
+              value={selectedRating / ratingScaleMax}
               precision={0.1}
               max={1}
               sx={{
                 fontSize: 70,
-                color: "#94ec01",
+                color: questionCategory === "Overall" ? "#94ec01" : smallStarColor,
               }}
-              emptyIcon={<StarIcon style={{ opacity: .40, color: "#737373" }} fontSize="inherit" />}
+              emptyIcon={<StarIcon style={{ opacity: 0.4, color: "#737373" }} fontSize="inherit" />}
             />
           </div>
         </div>

--- a/app/core/components/ArticleList.tsx
+++ b/app/core/components/ArticleList.tsx
@@ -1,21 +1,17 @@
 import React, { Suspense } from "react"
-import { Head, useQuery } from "blitz"
+import { useQuery } from "blitz"
 import Article from "./Article"
 import getArticlesWithReview from "app/queries/getArticlesWithReview"
 import algoliasearch from "algoliasearch"
-import {
-  InstantSearch,
-  SortBy,
-  Hits,
-  Configure,
-} from "react-instantsearch-hooks-web"
+import { InstantSearch, SortBy, Hits, Configure } from "react-instantsearch-hooks-web"
 
 const searchClient = algoliasearch(
   process.env.ALGOLIA_APP_ID as string,
   process.env.ALGOLIA_API_SEARCH_KEY as string
 )
 
-export default function ArticleList() {
+export default function ArticleList(props) {
+  const { questionCategory } = props
   const [defaultArticles] = useQuery(getArticlesWithReview, undefined)
   const Hit = ({ hit }) => {
     return (
@@ -34,18 +30,43 @@ export default function ArticleList() {
           ratingInterpretation={hit.ratingInterpretation}
           ratingSignificance={hit.ratingSignificance}
           ratingsCount={hit.ratingsCount}
+          questionCategory={questionCategory}
         />
       </Suspense>
     )
   }
 
+  // Determine Algolia suffixes
+  var ratingSuffix
+  switch (questionCategory) {
+    case "Overall":
+      ratingSuffix = "ratingTotal"
+      break
+    case "Research Question":
+      ratingSuffix = "ratingRQ"
+      break
+    case "Design":
+      ratingSuffix = "ratingDesign"
+      break
+    case "Findings":
+      ratingSuffix = "ratingFindings"
+      break
+    case "Interpretation":
+      ratingSuffix = "ratingInterpretation"
+      break
+    case "Significance":
+      ratingSuffix = "ratingSignificance"
+      break
+  }
 
   const targetScores = [
-    { label: "Review score", suffix: "ratingTotal" },
+    { label: "Review score", suffix: ratingSuffix },
     { label: "Date added", suffix: "dateAdded" },
   ]
 
-  const defaultSortItem = [{ label: "Number of reviews", value: `${process.env.ALGOLIA_PREFIX}_articles` }]
+  const defaultSortItem = [
+    { label: "Number of reviews", value: `${process.env.ALGOLIA_PREFIX}_articles` },
+  ]
   const sortItems = defaultSortItem.concat(
     targetScores.map((target) => {
       return {

--- a/app/core/components/NavDots.tsx
+++ b/app/core/components/NavDots.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+
+const Dot = (props) => {
+  return (
+    <div
+      {...props}
+      className={`${props.selected ? "w-5 h-5" : "w-3 h-3 hover:h-3 hover:w-3"}\
+   ${props.category === "Overall" ? "bg-green" : "bg-white"} rounded-full \
+    hover:cursor-pointer \
+    `}
+    ></div>
+  )
+}
+
+export const NavDots = (props) => {
+  const { searchCategories, setQuestionCategory, questionCategory } = props
+
+  return (
+    <div id="dot-area" className="mx-auto w-72 fixed inset-x-0 bottom-16">
+      <div
+        id="dot-bar"
+        className="px-4 flex flex-row h-12 rounded-3xl bg-gray-dark bg-opacity-80 items-center justify-around"
+      >
+        {searchCategories.map((category) => (
+          <Dot
+            key={category}
+            onClick={() => setQuestionCategory(category)}
+            selected={category === questionCategory}
+            category={category}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/core/components/NavDots.tsx
+++ b/app/core/components/NavDots.tsx
@@ -4,9 +4,10 @@ const Dot = (props) => {
   return (
     <div
       {...props}
-      className={`${props.selected ? "w-5 h-5" : "w-3 h-3 hover:h-3 hover:w-3"}\
+      className={`${props.selected ? "w-5 h-5" : "w-3 h-3"}\
    ${props.category === "Overall" ? "bg-green" : "bg-white"} rounded-full \
     hover:cursor-pointer \
+    transition-all
     `}
     ></div>
   )

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Import font */
+@import url("https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@1,300&display=swap");
+
 @layer components {
   .hero {
     @apply w-full text-[#333];

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* Import font */
-@import url("https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@1,300&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;600;700&display=swap");
 
 @layer components {
   .hero {

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense } from "react"
-import { useRouter, useSession, BlitzPage, noSSR } from "blitz"
+import React, { Suspense, useEffect, useState } from "react"
+import { useRouter, useSession, BlitzPage, noSSR, useQuery } from "blitz"
 import Layout from "app/core/layouts/Layout"
 
 // Components
@@ -8,23 +8,86 @@ import { Footer } from "app/core/components/Footer"
 import { Hero } from "app/core/components/Hero"
 import { HowItWorks } from "app/core/components/HowItWorks"
 import ArticleList from "app/core/components/ArticleList"
+import getQuestionCategories from "app/queries/getQuestionCategories"
+import { NavDots } from "app/core/components/NavDots"
 
 const UserInfo = () => {
   const router = useRouter()
   const session = useSession()
+  const [questionCategories] = useQuery(getQuestionCategories, undefined)
+  const [questionCategory, setQuestionCategory] = useState("Overall")
+  const questionCategoryLabels = questionCategories.map(
+    (category) => category.questionCategory
+  ) as any
+  const allLabels = ["Overall"].concat(questionCategoryLabels)
+  const [searchCategories, setSearchCategories] = useState(allLabels)
+
+  const handleArrowClick = (direction) => {
+    if (direction === "right") {
+      const nextCategoryIndex = searchCategories.indexOf(questionCategory) + 1
+      // Don't fire if the next item is undefined
+      if (!searchCategories[nextCategoryIndex]) return undefined
+      setQuestionCategory(searchCategories[nextCategoryIndex]!)
+    }
+    if (direction === "left") {
+      const nextCategoryIndex = searchCategories.indexOf(questionCategory) - 1
+      // Don't fire if the next item is undefined
+      if (!searchCategories[nextCategoryIndex]) return undefined
+      setQuestionCategory(searchCategories[nextCategoryIndex]!)
+    }
+  }
+  // Key event listener
+  const handleKeyEvent = (e: KeyboardEvent) => {
+    if (e.isComposing || e.key === "ArrowLeft") {
+      handleArrowClick("left")
+    }
+    if (e.isComposing || e.key === "ArrowRight") {
+      handleArrowClick("right")
+    }
+  }
+  // Attach key event listener when the question category changes
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyEvent, false)
+    return () => window.removeEventListener("keydown", handleKeyEvent, false)
+  }, [questionCategory])
 
   if (session.userId) {
     return (
       <div className="w-full bg-black items-center">
         <div id="header-category container" className="flex flex-col items-center">
-          <div id="reviews-header" className="mt-10 mb-2 items-center font-semibold text-5xl text-gray-medium">
+          <div
+            id="reviews-header"
+            className="mt-10 mb-2 items-center font-semibold text-5xl text-gray-medium"
+          >
             All Reviews
           </div>
-          <div id="overall-reviews" className="items-center text-4xl font-bold text-white hover:cursor-pointer">
-            Overall
+          <div
+            id="overall-reviews"
+            className="items-center flex flex-row font-bold text-white hover:cursor-pointer"
+          >
+            <span
+              className={`mr-4 ${questionCategory === "Overall" && "invisible"}`}
+              onClick={() => handleArrowClick("left")}
+            >
+              {"<<"}
+            </span>
+            <div className="text-4xl w-80 text-center">{questionCategory}</div>
+            <span
+              className={`ml-4 ${
+                questionCategory === searchCategories.slice(-1)[0] && "invisible"
+              }`}
+              onClick={() => handleArrowClick("right")}
+            >
+              {">>"}
+            </span>
           </div>
           <ArticleList />
         </div>
+        <NavDots
+          searchCategories={searchCategories}
+          questionCategory={questionCategory}
+          setQuestionCategory={setQuestionCategory}
+        />
       </div>
     )
   } else {

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -63,17 +63,17 @@ const UserInfo = () => {
           </div>
           <div
             id="overall-reviews"
-            className="items-center flex flex-row font-bold text-white hover:cursor-pointer"
+            className="items-center flex flex-row font-bold text-white hover:cursor-pointer overflow-x-clip"
           >
             <span
-              className={`mr-4 ${questionCategory === "Overall" && "invisible"}`}
+              className={`mr-1 ${questionCategory === "Overall" && "invisible"}`}
               onClick={() => handleArrowClick("left")}
             >
               {"<<"}
             </span>
             <div className="text-4xl w-80 text-center">{questionCategory}</div>
             <span
-              className={`ml-4 ${
+              className={`ml-1 ${
                 questionCategory === searchCategories.slice(-1)[0] && "invisible"
               }`}
               onClick={() => handleArrowClick("right")}

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -81,7 +81,7 @@ const UserInfo = () => {
               {">>"}
             </span>
           </div>
-          <ArticleList />
+          <ArticleList questionCategory={questionCategory} />
         </div>
         <NavDots
           searchCategories={searchCategories}


### PR DESCRIPTION
This PR allows viewing articles through the summary scores by question categories. Fixes #270.

### TODO:

Currently,  a "Sort by" selection does not persist when the user changes the category:

https://user-images.githubusercontent.com/17035406/185762581-f2e36e3a-7ed1-437c-9a1e-593508190c26.mov

It would make sense for the sorting to persist even when the user moves from one category to another. 