### PR TITLE
Show add article button when no user review or no review

### DIFF
--- a/app/pages/articles/[articleId].tsx
+++ b/app/pages/articles/[articleId].tsx
@@ -342,7 +342,7 @@ const ArticleDetails = (props) => {
             </div>
           </AccordionDetails>
         </Accordion>
-        {!userHasReview && (
+        {(!userHasReview || !articleHasReview) && (
           <div className="m-16">
             <button
               className="px-4 py-4 text-xl text-green rounded-lg bg-black/50 hover:bg-gray-darkest dark:bg-gray-medium dark:hover:bg-black/40"


### PR DESCRIPTION
This PR fixes the issue of the "add article" button not showing up.

The procedure to recreate the problem was:

1. Log in
2. Navigate to an article with your review
3. Search and navigate to an article without any review

The problem should not be happening with this PR.

Fixes #252. 