### PR TITLE
Use absolute paths in the drawer to the code of conduct page and terms of use page

### DIFF
--- a/app/core/components/DrawerMenu.tsx
+++ b/app/core/components/DrawerMenu.tsx
@@ -88,13 +88,13 @@ export const DrawerMenu = () => {
                 <Typography>Policies</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <ListItemButton sx={{ ...hoverSx }} onClick={() => router.push("terms-of-use")}>
+                <ListItemButton sx={{ ...hoverSx }} onClick={() => router.push("/terms-of-use")}>
                   <ListItemText primary={"Terms of use"} />
                 </ListItemButton>
                 <ListItemButton sx={{ ...hoverSx }}>
                   <ListItemText primary={"Privacy policy"} />
                 </ListItemButton>
-                <ListItemButton sx={{ ...hoverSx }} onClick={() => router.push("code-of-conduct")}>
+                <ListItemButton sx={{ ...hoverSx }} onClick={() => router.push("/code-of-conduct")}>
                   <ListItemText primary={"Code of conduct"} />
                 </ListItemButton>
               </AccordionDetails>


### PR DESCRIPTION
This PR use the absolute paths to link to the code of conduct page and the teams of use page.

Fixes #297.