### PR TITLE
Remove search bar for authentication pages

### DIFF
--- a/app/auth/pages/forgot-password.tsx
+++ b/app/auth/pages/forgot-password.tsx
@@ -20,7 +20,7 @@ const ForgotPasswordPage: BlitzPage = () => {
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
-        <Navbar />
+        <Navbar hideSearch={true} />
       </Suspense>
       <main className="flex-grow flex flex-col items-center justify-start">
         <div className="contrast-100 mt-6 h-48 w-full flex justify-center">

--- a/app/auth/pages/login.tsx
+++ b/app/auth/pages/login.tsx
@@ -28,7 +28,7 @@ const LoginPage: BlitzPage = () => {
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
-        <Navbar />
+        <Navbar hideSearch={true} />
       </Suspense>
       <main className="flex-grow flex flex-col items-center justify-center">
         <div className="contrast-100 mt-6 h-60 w-full flex justify-center">

--- a/app/auth/pages/reset-password.tsx
+++ b/app/auth/pages/reset-password.tsx
@@ -37,7 +37,7 @@ const ResetPasswordPage: BlitzPage = () => {
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
-        <Navbar />
+        <Navbar hideSearch={true} />
       </Suspense>
       <main className="flex-grow flex flex-col items-center justify-center">
         <div className="h-40 w-full flex justify-center">

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -30,7 +30,7 @@ const SignupPage: BlitzPage = () => {
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
-        <Navbar />
+        <Navbar hideSearch={true} />
       </Suspense>
       <main className="flex-grow flex flex-col items-center justify-center">
         <div id="postReviewLogo" className="h-70 w-full flex justify-center">


### PR DESCRIPTION
This PR hides the search bar on the authentication(log-in, sign-up, forgot password, reset password) pages.

Fixes #311 
![localhost_3000_reset-password(iPhone XR) (1)](https://user-images.githubusercontent.com/42837484/186269799-96f54bba-f55f-46b8-9e71-5a237638a95e.png)
![localhost_3000_reset-password(iPhone XR) (2)](https://user-images.githubusercontent.com/42837484/186269800-fa7015dc-736b-4034-a22b-9b1bb8f18ce2.png)
![localhost_3000_reset-password(iPhone XR) (3)](https://user-images.githubusercontent.com/42837484/186269803-ab9df6a0-7f22-4064-b2a8-3a043811bab7.png)
![localhost_3000_reset-password(iPhone XR) (4)](https://user-images.githubusercontent.com/42837484/186269806-1693db6a-c2fc-4f3d-bad2-ddf0cb1afb7c.png)

