### PR TITLE
Update the Algolia index when deleting a review

### DIFF
--- a/app/mutations/addReview.tsx
+++ b/app/mutations/addReview.tsx
@@ -1,13 +1,7 @@
 import db from "db"
 import { Ctx, AuthorizationError } from "blitz"
 import * as z from "zod"
-import algoliasearch from "algoliasearch"
-import getArticleScoresById from "app/queries/getArticleScoresById"
-import getUsersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByArticleId"
-
-// Initialize Algolia
-const client = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_ADMIN_KEY!)
-const index = client.initIndex(`${process.env.ALGOLIA_PREFIX}_articles`)
+import { updateArticleIndex } from "./helpers/updateArticleIndex"
 
 const AddReview = z.array(
   z.object({
@@ -52,37 +46,8 @@ export default async function addReview(input: z.infer<typeof AddReview>, ctx: C
   // Delete any null responses
   const deleted = await db.reviewAnswers.deleteMany({ where: { response: null } })
 
-  // Update article metadata on Algolia
-  // Get the new scores for the article
-  const articleScores = await getArticleScoresById({ currentArticleId: data[0]?.articleId })
-  const totalRating = articleScores.reduce((prev, current) => {
-    return prev + current._avg.response! / articleScores.length
-  }, 0)
-
-  const addedArticle = await db.article.findFirst({
-    where: {
-      id: data[0]?.articleId,
-    },
-  })
-
-  const usersWithReview = await getUsersWithReviewsByArticleId({
-    currentArticleId: addedArticle?.id,
-  })
-  const ratingsCount = usersWithReview.length
-
-  // Save the metadata to Algolia
-  // TODO: Streamline the data structure to accommodate multiple review versions
-  //       Group by versions, {questionId: XX, questionLabel: XX, response: XX}
-  await index.partialUpdateObject({
-    objectID: addedArticle?.id,
-    ratingsCount: ratingsCount,
-    ratingTotal: totalRating,
-    ratingRQ: articleScores.find((item) => item.questionId == 1)?._avg.response,
-    ratingDesign: articleScores.find((item) => item.questionId == 2)?._avg.response,
-    ratingFindings: articleScores.find((item) => item.questionId == 3)?._avg.response,
-    ratingInterpretation: articleScores.find((item) => item.questionId == 4)?._avg.response,
-    ratingSignificance: articleScores.find((item) => item.questionId == 5)?._avg.response,
-  })
+  // Update Algolia index
+  updateArticleIndex(data[0]?.articleId)
 
   return review
 }

--- a/app/mutations/deleteReview.tsx
+++ b/app/mutations/deleteReview.tsx
@@ -1,5 +1,6 @@
 import db from "db"
 import { Ctx, AuthorizationError } from "blitz"
+import { updateArticleIndex } from "./helpers/updateArticleIndex"
 
 export default async function deleteReview(currentArticleId: string, ctx: Ctx) {
   ctx.session.$authorize()
@@ -16,6 +17,9 @@ export default async function deleteReview(currentArticleId: string, ctx: Ctx) {
       userId: currentUserId,
     },
   })
+
+  // Update Algolia Index
+  updateArticleIndex(currentArticleId)
 
   return review
 }

--- a/app/mutations/helpers/updateArticleIndex.tsx
+++ b/app/mutations/helpers/updateArticleIndex.tsx
@@ -1,0 +1,42 @@
+import db from "db"
+import algoliasearch from "algoliasearch"
+import getArticleScoresById from "app/queries/getArticleScoresById"
+import getUsersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByArticleId"
+
+// Initialize Algolia
+const client = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_ADMIN_KEY!)
+const index = client.initIndex(`${process.env.ALGOLIA_PREFIX}_articles`)
+
+export const updateArticleIndex = async (articleId) => {
+  // Update article metadata on Algolia
+  // Get the new scores for the article
+  const articleScores = await getArticleScoresById({ currentArticleId: articleId })
+  const totalRating = articleScores.reduce((prev, current) => {
+    return prev + current._avg.response! / articleScores.length
+  }, 0)
+
+  const addedArticle = await db.article.findFirst({
+    where: {
+      id: articleId,
+    },
+  })
+
+  const usersWithReview = await getUsersWithReviewsByArticleId({
+    currentArticleId: addedArticle?.id,
+  })
+  const ratingsCount = usersWithReview.length
+
+  // Save the metadata to Algolia
+  // TODO: Streamline the data structure to accommodate multiple review versions
+  //       Group by versions, {questionId: XX, questionLabel: XX, response: XX}
+  await index.partialUpdateObject({
+    objectID: addedArticle?.id,
+    ratingsCount: ratingsCount,
+    ratingTotal: totalRating,
+    ratingRQ: articleScores.find((item) => item.questionId == 1)?._avg.response,
+    ratingDesign: articleScores.find((item) => item.questionId == 2)?._avg.response,
+    ratingFindings: articleScores.find((item) => item.questionId == 3)?._avg.response,
+    ratingInterpretation: articleScores.find((item) => item.questionId == 4)?._avg.response,
+    ratingSignificance: articleScores.find((item) => item.questionId == 5)?._avg.response,
+  })
+}


### PR DESCRIPTION
This PR adds a routine to update the Algolia index when deleting a review. Fixes #318.

The updating routine is factored out as `app/mutations/helpers/updateArticleIndex.tsx`. 