### PR TITLE
Add consent to policies on sign-up page

### DIFF
--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -82,6 +82,15 @@ const SignupPage: BlitzPage = () => {
                   errors.password = "Password should be 10 or more characters"
                 }
 
+                if (!values.terms) {
+                  errors.terms =
+                    "Please read our Terms of Use and Privacy Policy and click to agree"
+                }
+
+                if (!values.coc) {
+                  errors.coc = "Please read our CoC and click to agree"
+                }
+
                 return errors
               })
             }}

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -179,6 +179,63 @@ const SignupPage: BlitzPage = () => {
                     {isPasswordHidden ? <BsEyeSlash /> : <BsEye />}
                   </button>
                 </div>
+                <div className="flex flex-row w-80 items-center">
+                  <ThemeProvider theme={theme}>
+                    <Switch
+                      color="success"
+                      name="terms"
+                      value={values.terms}
+                      onChange={handleChange}
+                    ></Switch>
+                  </ThemeProvider>
+                  <div className="my-4 inline text-gray-darkest dark:text-white">
+                    I agree to the{" "}
+                    <Link href={Routes.TermsofUsePage()}>
+                      <a
+                        className="underline italic text-gray-dark dark:text-white/90 hover:text-black"
+                        target="_blank"
+                      >
+                        Terms of Use
+                      </a>
+                    </Link>{" "}
+                    and{" "}
+                    <Link href={Routes.PrivacyPolicyPage()}>
+                      <a
+                        className="underline italic text-gray-dark dark:text-white/90 hover:text-black"
+                        target="_blank"
+                      >
+                        Privacy Policy
+                      </a>
+                    </Link>
+                    <div className="text-xs font-semibold text-red">
+                      {errors.terms && touched.terms && " - " + errors.terms}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-row w-80 items-center">
+                  <ThemeProvider theme={theme}>
+                    <Switch
+                      color="success"
+                      name="coc"
+                      value={values.coc}
+                      onChange={handleChange}
+                    ></Switch>
+                  </ThemeProvider>
+                  <div className="my-4 inline text-gray-darkest dark:text-white">
+                    I agree to the{" "}
+                    <Link href={Routes.CodeOfConductPage()}>
+                      <a
+                        className="underline italic text-gray-dark dark:text-white/90 hover:text-black"
+                        target="_blank"
+                      >
+                        Code of Conduct
+                      </a>
+                    </Link>
+                    <div className="text-xs font-semibold text-red">
+                      {errors.coc && touched.coc && " - " + errors.coc}
+                    </div>
+                  </div>
+                </div>
                 <Button addstyles="my-4" type="submit" disabled={isSubmitting}>
                   Sign up
                 </Button>
@@ -190,7 +247,7 @@ const SignupPage: BlitzPage = () => {
           <div className="my-4 text-gray-darkest dark:text-white">
             Already have an account?{" "}
             <Link href={Routes.LoginPage()}>
-              <a className="text-sm text-center underline italic text-gray-dark dark:text-white/70">
+              <a className="text-sm text-center underline italic text-gray-dark dark:text-white/90 hover:text-gray-darkest">
                 Log in
               </a>
             </Link>

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -28,6 +28,18 @@ const SignupPage: BlitzPage = () => {
     setIsDark(mediaQuery.matches)
   }, [])
 
+  // Theme override
+  const theme = createTheme({
+    palette: {
+      success: {
+        light: "#ffffff",
+        main: "#94ec01",
+        dark: "#2e2c2c",
+        contrastText: "rgba(0, 0, 0, 0.87)",
+      },
+    },
+  })
+
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -10,6 +10,7 @@ import { Button } from "app/core/components/Button"
 import postReviewLogoDarkMode from "public/logo-darkmode.png"
 import postReviewLogoLightMode from "public/logo-lightmode.png"
 import { BsEye, BsEyeSlash } from "react-icons/bs"
+import { createTheme, Switch, ThemeProvider } from "@mui/material"
 
 const SignupPage: BlitzPage = () => {
   const router = useRouter()

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -112,7 +112,7 @@ const SignupPage: BlitzPage = () => {
             }) => (
               <form onSubmit={handleSubmit} className="flex flex-col">
                 {showError && (
-                  <div className="bg-red/50 rounded-md text-gray-darkest text-center p-3">
+                  <div className="bg-black/60 rounded-md text-red text-center p-2">
                     This email is already used
                   </div>
                 )}

--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -59,7 +59,7 @@ const SignupPage: BlitzPage = () => {
         </h1>
         <div className="flex flex-col items-center py-6 px-10 bg-gray-light dark:bg-gray-dark">
           <Formik
-            initialValues={{ email: "", password: "", handle: "" }}
+            initialValues={{ email: "", password: "", handle: "", terms: false, coc: false }}
             validate={(values) => {
               const existingUser = invoke(getUserInfo, { userHandle: values.handle })
               return existingUser.then((foundUser) => {


### PR DESCRIPTION
This PR adds the consent to policies (Terms of Use, Privacy Policy, and Code of Conduct) section on the sign-up page.

This PR also changes the styling of the "email already in use" error message for more visibility.

Fixes #281 

![localhost_3000_signup(iPhone XR) (7)](https://user-images.githubusercontent.com/42837484/186304610-3cd5e81f-cf15-403c-bc68-f84bb1210e7e.png)
![localhost_3000_signup(iPhone XR) (6)](https://user-images.githubusercontent.com/42837484/186304625-82914a48-276e-497e-bddf-d7da4b9182e4.png)

