### PR TITLE
Fix the margin of the search bar 

### DIFF
--- a/app/core/components/DrawerMenu.tsx
+++ b/app/core/components/DrawerMenu.tsx
@@ -1,7 +1,6 @@
 import {
   AccordionDetails,
   AccordionSummary,
-  Button,
   Drawer,
   List,
   ListItemButton,
@@ -9,7 +8,7 @@ import {
   Typography,
 } from "@mui/material"
 import { Image, useRouter, useSession } from "blitz"
-import React, { useState } from "react"
+import React from "react"
 import postReviewIcon from "/public/logo-withname-lightmode.png"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import MuiAccordion, { AccordionProps } from "@mui/material/Accordion"
@@ -19,14 +18,10 @@ import styled from "@emotion/styled"
 import { FaGithub, FaDiscord, FaBars } from "react-icons/fa"
 import { AiFillTwitterCircle } from "react-icons/ai"
 
-export const DrawerMenu = () => {
+export const DrawerMenu = (props) => {
+  const { open, setOpen } = props
   const session = useSession()
-  const [open, setOpen] = useState(false)
   const router = useRouter()
-
-  const toggleDrawer = () => {
-    setOpen(!open)
-  }
 
   // Style the MUI components
   const Accordion = styled((props: AccordionProps) => (
@@ -52,12 +47,6 @@ export const DrawerMenu = () => {
 
   return (
     <>
-      <button
-        onClick={() => toggleDrawer()}
-        className={"fixed text-4xl top-4 left-4 text-gray-medium"}
-      >
-        <FaBars />
-      </button>
       <Drawer anchor={"left"} open={open} onClose={() => setOpen(false)}>
         <div className="w-full h-full bg-gray-light flex flex-col overflow-clip">
           <div id="logo-container" className="ml-8">

--- a/app/core/components/HeaderUserButton.tsx
+++ b/app/core/components/HeaderUserButton.tsx
@@ -94,12 +94,12 @@ export const HeaderUserButton = () => {
         <>
           <button
             id="login-button"
-            className="font-semibold mx-2 rounded-md px-3 py-2 whitespace-nowrap flex items-center justify-center text-gray-darkest dark:text-white bg-gray-light dark:bg-gray-medium hover:bg-gray-medium dark:hover:bg-gray-darkest hover:text-white"
+            className="font-semibold rounded-md px-3 py-2 whitespace-nowrap flex items-center justify-center text-gray-darkest dark:text-white bg-gray-light dark:bg-gray-medium hover:bg-gray-medium dark:hover:bg-gray-darkest hover:text-white"
             onClick={() => router.push(Routes.LoginPage())}
           >
             Log in
           </button>
-          <Button id="login-button" onClick={() => router.push(Routes.SignupPage())}>
+          <Button id="sign-up-button" onClick={() => router.push(Routes.SignupPage())}>
             Sign up
           </Button>
         </>

--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -1,8 +1,9 @@
-import React from "react"
+import React, { useState } from "react"
 import { HeaderUserButton } from "./HeaderUserButton"
 import EnterDOI from "./EnterDOI"
 import { useRouter, useSession, useRouterQuery } from "blitz"
 import { DrawerMenu } from "./DrawerMenu"
+import { FaBars } from "react-icons/fa"
 
 export default function Navbar(props) {
   const { hideSearch } = props
@@ -11,10 +12,20 @@ export default function Navbar(props) {
   const isAtRoot = router.pathname === "/"
   const query = useRouterQuery()
 
+  const [open, setOpen] = useState(false)
+  const toggleDrawer = () => {
+    setOpen(!open)
+  }
+
   return (
     <>
       <nav className="bg-gradient-to-r from-gray-darkest to-gray-dark flex flex-row items-center h-16 fixed z-50 w-full">
-        <div className="w-16" />
+        <button
+          onClick={() => toggleDrawer()}
+          className={"mx-4 text-4xl top-4 left-4 text-gray-medium outline-white"}
+        >
+          <FaBars />
+        </button>
         <div id="search-bar-container" className="flex flex-grow justify-center">
           {hideSearch ? undefined : session?.userId ? (
             <EnterDOI session={session} />
@@ -25,7 +36,7 @@ export default function Navbar(props) {
         <div id="buttons-container" className="mx-4 flex flex-row">
           <HeaderUserButton />
         </div>
-        <DrawerMenu />
+        <DrawerMenu open={open} setOpen={setOpen} />
       </nav>
       <div className="h-16 w-full" />
     </>

--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar(props) {
             (!isAtRoot || query.search) && <EnterDOI session={session} />
           )}
         </div>
-        <div id="buttons-container" className="mx-4 flex flex-row">
+        <div id="buttons-container" className="mx-1 flex flex-row">
           <HeaderUserButton />
         </div>
         <DrawerMenu open={open} setOpen={setOpen} />


### PR DESCRIPTION
This PR adjusts the margin of the nav bar components so that the menu icon will have some breathing margins even with the log-in and sign-up buttons. Fixes #310.

![localhost_3000_(iPhone XR)](https://user-images.githubusercontent.com/17035406/186554378-a4bedd68-adc5-418e-8502-c0067ea09fa5.png)
 