### PR TITLE
Add expand & collapse all to the terms, privacy policy, and the code of conduct pages' accordion components

### DIFF
--- a/app/pages/code-of-conduct.tsx
+++ b/app/pages/code-of-conduct.tsx
@@ -10,7 +10,6 @@ import MuiAccordion, { AccordionProps } from "@mui/material/Accordion"
 import MuiAccordionSummary, { AccordionSummaryProps } from "@mui/material/AccordionSummary"
 import MuiAccordionDetails from "@mui/material/AccordionDetails"
 import Typography from "@mui/material/Typography"
-import { color } from "@mui/system"
 
 const Accordion = styled((props: AccordionProps) => (
   <MuiAccordion disableGutters elevation={0} square {...props} />
@@ -60,6 +59,31 @@ const accordionStyle = {
 }
 
 const CodeOfConductPage: BlitzPage = () => {
+  // Track the state of individual accordion
+  const [accordion, setAccordion] = React.useState({
+    standards: false,
+    responsibilities: false,
+    scope: false,
+    enforcement: false,
+    guidelines: false,
+    attribution: false,
+  })
+
+  // Handle click for each accordion
+  const handleClick = (key: string) => {
+    setAccordion({ ...accordion, [key]: !accordion[key] })
+  }
+  // Track the expand all button
+  const [expandClicked, setExpandClicked] = React.useState(false)
+  // Handle expand all accordions
+  const handleExpandAll = (expand = true) => {
+    Object.keys(accordion).forEach((key) => {
+      if (expand) return (accordion[key] = true)
+      if (!expand) return (accordion[key] = false)
+    })
+    setAccordion({ ...accordion })
+    setExpandClicked(!expandClicked)
+  }
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
@@ -97,7 +121,19 @@ const CodeOfConductPage: BlitzPage = () => {
           </p>
         </div>
         <div id="code-of-conduct-content" className="max-w-3xl">
-          <Accordion sx={{ ...accordionStyle }}>
+          <div className="text-right">
+            <button
+              className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-black dark:text-gray-light"
+              onClick={() => handleExpandAll(!expandClicked)}
+            >
+              {expandClicked ? "Collapse" : "Expand All"}
+            </button>
+          </div>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.standards}
+            onClick={() => handleClick("standards")}
+          >
             <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
               <Typography variant="h5">Our Standards</Typography>
             </AccordionSummary>
@@ -144,7 +180,11 @@ const CodeOfConductPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.responsibilities}
+            onClick={() => handleClick("responsibilities")}
+          >
             <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
               <Typography variant="h5">Enforcement Responsibilities</Typography>
             </AccordionSummary>
@@ -162,7 +202,11 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.scope}
+            onClick={() => handleClick("scope")}
+          >
             <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
               <Typography variant="h5">Scope</Typography>
             </AccordionSummary>
@@ -176,7 +220,11 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.enforcement}
+            onClick={() => handleClick("enforcement")}
+          >
             <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
               <Typography variant="h5">Enforcement</Typography>
             </AccordionSummary>
@@ -228,7 +276,11 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.guidelines}
+            onClick={() => handleClick("guidelines")}
+          >
             <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
               <Typography variant="h5">Enforcement Guidelines</Typography>
             </AccordionSummary>
@@ -295,7 +347,11 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.attribution}
+            onClick={() => handleClick("attribution")}
+          >
             <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
               <Typography variant="h5">Attribution</Typography>
             </AccordionSummary>

--- a/app/pages/privacy-policy.tsx
+++ b/app/pages/privacy-policy.tsx
@@ -135,7 +135,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </Accordion>
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
-              <Typography className="font-bold text-2xl">Personal Data</Typography>
+              <Typography className="font-bold text-2xl">Personal data</Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
               <p className="mx-2 font-thin text-black/90 dark:text-white">
@@ -267,7 +267,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel7d-content" id="panel7d-header">
               <Typography className="font-bold text-2xl">
-                Retention of Your Personal Data
+                Retention of your personal data
               </Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
@@ -290,7 +290,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </Accordion>
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel8d-content" id="panel8d-header">
-              <Typography className="font-bold text-2xl">Transfer of Your Personal Data</Typography>
+              <Typography className="font-bold text-2xl">Transfer of your personal data</Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
               <ul className="mx-4 my-4 font-thin list-decimal">
@@ -330,7 +330,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel9d-content" id="panel9d-header">
               <Typography className="font-bold text-2xl">
-                Disclosure of Your Personal Data
+                Disclosure of your personal data
               </Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
@@ -364,7 +364,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </Accordion>
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel10d-content" id="panel10d-header">
-              <Typography className="font-bold text-2xl">Security of Your Personal Data</Typography>
+              <Typography className="font-bold text-2xl">Security of your personal data</Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
               <p className="mx-2 my-3 font-thin text-black/90 dark:text-white/90">
@@ -377,7 +377,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </Accordion>
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel11d-content" id="panel11d-header">
-              <Typography className="font-bold text-2xl">Changes to this Privacy Policy</Typography>
+              <Typography className="font-bold text-2xl">Changes to this privacy policy</Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
               <ul className="mx-4 my-4 font-thin list-decimal">
@@ -395,7 +395,7 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </Accordion>
           <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
             <AccordionSummary aria-controls="panel12d-content" id="panel12d-header">
-              <Typography className="font-bold text-2xl">Contact Us</Typography>
+              <Typography className="font-bold text-2xl">Contact us</Typography>
             </AccordionSummary>
             <AccordionDetails className="bg-gray-medium dark:bg-gray-dark text-black/80 dark:text-white/80">
               <p className="mx-2 my-3 font-thin text-black/90 dark:text-white/90">

--- a/app/pages/privacy-policy.tsx
+++ b/app/pages/privacy-policy.tsx
@@ -46,6 +46,38 @@ const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
 }))
 
 const PrivacyPolicyPage: BlitzPage = () => {
+  // Track the state of individual accordion
+  const [accordion, setAccordion] = React.useState({
+    definitions: false,
+    personal: false,
+    usage: false,
+    cookies: false,
+    purposes: false,
+    share: false,
+    retention: false,
+    transfer: false,
+    disclosure: false,
+    security: false,
+    changes: false,
+    contact: false,
+  })
+
+  // Handle click for each accordion
+  const handleClick = (key: string) => {
+    setAccordion({ ...accordion, [key]: !accordion[key] })
+  }
+  // Track the expand all button
+  const [expandClicked, setExpandClicked] = React.useState(false)
+  // Handle expand all accordions
+  const handleExpandAll = (expand = true) => {
+    Object.keys(accordion).forEach((key) => {
+      if (expand) return (accordion[key] = true)
+      if (!expand) return (accordion[key] = false)
+    })
+    setAccordion({ ...accordion })
+    setExpandClicked(!expandClicked)
+  }
+
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
@@ -84,7 +116,20 @@ const PrivacyPolicyPage: BlitzPage = () => {
           </p>
         </div>
         <div id="terms-of-use-content" className="max-w-3xl">
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <div className="text-right">
+            <button
+              className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-black dark:text-gray-light"
+              onClick={() => handleExpandAll(!expandClicked)}
+            >
+              {expandClicked ? "Collapse" : "Expand All"}
+            </button>
+          </div>
+
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.definitions}
+            onClick={() => handleClick("definitions")}
+          >
             <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
               <Typography className="font-bold text-2xl">Definitions</Typography>
             </AccordionSummary>
@@ -133,7 +178,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.personal}
+            onClick={() => handleClick("personal")}
+          >
             <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
               <Typography className="font-bold text-2xl">Personal data</Typography>
             </AccordionSummary>
@@ -145,7 +194,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.usage}
+            onClick={() => handleClick("usage")}
+          >
             <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
               <Typography className="font-bold text-2xl">Usage data</Typography>
             </AccordionSummary>
@@ -168,7 +221,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.cookies}
+            onClick={() => handleClick("cookies")}
+          >
             <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
               <Typography className="font-bold text-2xl">Cookies</Typography>
             </AccordionSummary>
@@ -194,7 +251,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.purposes}
+            onClick={() => handleClick("purposes")}
+          >
             <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
               <Typography className="font-bold text-2xl">
                 Purposes of processing your data
@@ -236,7 +297,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.share}
+            onClick={() => handleClick("share")}
+          >
             <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
               <Typography className="font-bold text-2xl">
                 We may share your personal information
@@ -264,7 +329,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.retention}
+            onClick={() => handleClick("retention")}
+          >
             <AccordionSummary aria-controls="panel7d-content" id="panel7d-header">
               <Typography className="font-bold text-2xl">
                 Retention of your personal data
@@ -288,7 +357,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.transfer}
+            onClick={() => handleClick("transfer")}
+          >
             <AccordionSummary aria-controls="panel8d-content" id="panel8d-header">
               <Typography className="font-bold text-2xl">Transfer of your personal data</Typography>
             </AccordionSummary>
@@ -327,7 +400,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.disclosure}
+            onClick={() => handleClick("disclosure")}
+          >
             <AccordionSummary aria-controls="panel9d-content" id="panel9d-header">
               <Typography className="font-bold text-2xl">
                 Disclosure of your personal data
@@ -362,7 +439,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.security}
+            onClick={() => handleClick("security")}
+          >
             <AccordionSummary aria-controls="panel10d-content" id="panel10d-header">
               <Typography className="font-bold text-2xl">Security of your personal data</Typography>
             </AccordionSummary>
@@ -375,7 +456,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.changes}
+            onClick={() => handleClick("changes")}
+          >
             <AccordionSummary aria-controls="panel11d-content" id="panel11d-header">
               <Typography className="font-bold text-2xl">Changes to this privacy policy</Typography>
             </AccordionSummary>
@@ -393,7 +478,11 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion className="bg-gray-dark dark:bg-black/30 text-black dark:text-white">
+          <Accordion
+            className="bg-gray-dark dark:bg-black/30 text-black dark:text-white"
+            expanded={accordion.contact}
+            onClick={() => handleClick("contact")}
+          >
             <AccordionSummary aria-controls="panel12d-content" id="panel12d-header">
               <Typography className="font-bold text-2xl">Contact us</Typography>
             </AccordionSummary>

--- a/app/pages/terms-of-use.tsx
+++ b/app/pages/terms-of-use.tsx
@@ -73,8 +73,7 @@ const TermsofUsePage: BlitzPage = () => {
     contact: false,
     acknowledgement: false,
   })
-  // Track the state of expand all
-  const [expandAll, setExpandAll] = React.useState(false)
+
   // Handle click for each accordion
   const handleClick = (key: string) => {
     setAccordion({ ...accordion, [key]: !accordion[key] })

--- a/app/pages/terms-of-use.tsx
+++ b/app/pages/terms-of-use.tsx
@@ -107,15 +107,16 @@ const TermsofUsePage: BlitzPage = () => {
             height={200}
           />
         </div>
-        <div className="self-end">
-          <button
-            className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-gray-light"
-            onClick={() => handleExpandAll(!expandClicked)}
-          >
-            {expandClicked ? "Collapse" : "Expand All"}
-          </button>
-        </div>
         <div id="terms-of-use-content" className="max-w-3xl">
+          <div className="text-right">
+            <button
+              className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-black dark:text-gray-light"
+              onClick={() => handleExpandAll(!expandClicked)}
+            >
+              {expandClicked ? "Collapse" : "Expand All"}
+            </button>
+          </div>
+
           <Accordion
             sx={{ ...accordionStyle }}
             expanded={accordion.scope}

--- a/app/pages/terms-of-use.tsx
+++ b/app/pages/terms-of-use.tsx
@@ -78,12 +78,16 @@ const TermsofUsePage: BlitzPage = () => {
   const handleClick = (key: string) => {
     setAccordion({ ...accordion, [key]: !accordion[key] })
   }
+  // Track the expand all button
+  const [expandClicked, setExpandClicked] = React.useState(false)
   // Handle expand all accordions
-  const handleExpandAll = () => {
+  const handleExpandAll = (expand = true) => {
     Object.keys(accordion).forEach((key) => {
-      return (accordion[key] = true)
+      if (expand) return (accordion[key] = true)
+      if (!expand) return (accordion[key] = false)
     })
     setAccordion({ ...accordion })
+    setExpandClicked(!expandClicked)
   }
 
   return (
@@ -106,9 +110,9 @@ const TermsofUsePage: BlitzPage = () => {
         <div className="self-end">
           <button
             className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-gray-light"
-            onClick={() => handleExpandAll()}
+            onClick={() => handleExpandAll(!expandClicked)}
           >
-            Expand All
+            {expandClicked ? "Collapse" : "Expand All"}
           </button>
         </div>
         <div id="terms-of-use-content" className="max-w-3xl">

--- a/app/pages/terms-of-use.tsx
+++ b/app/pages/terms-of-use.tsx
@@ -59,6 +59,34 @@ const accordionStyle = {
 }
 
 const TermsofUsePage: BlitzPage = () => {
+  // Track the state of individual accordion
+  const [accordion, setAccordion] = React.useState({
+    scope: false,
+    definitions: false,
+    agreement: false,
+    functions: false,
+    term: false,
+    availability: false,
+    data: false,
+    change: false,
+    law: false,
+    contact: false,
+    acknowledgement: false,
+  })
+  // Track the state of expand all
+  const [expandAll, setExpandAll] = React.useState(false)
+  // Handle click for each accordion
+  const handleClick = (key: string) => {
+    setAccordion({ ...accordion, [key]: !accordion[key] })
+  }
+  // Handle expand all accordions
+  const handleExpandAll = () => {
+    Object.keys(accordion).forEach((key) => {
+      return (accordion[key] = true)
+    })
+    setAccordion({ ...accordion })
+  }
+
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-darkest">
       <Suspense fallback="Loading...">
@@ -76,8 +104,20 @@ const TermsofUsePage: BlitzPage = () => {
             height={200}
           />
         </div>
+        <div className="self-end">
+          <button
+            className="px-2 py-1 mx-3 my-2 text-sm bg-gray-medium text-gray-light"
+            onClick={() => handleExpandAll()}
+          >
+            Expand All
+          </button>
+        </div>
         <div id="terms-of-use-content" className="max-w-3xl">
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.scope}
+            onClick={() => handleClick("scope")}
+          >
             <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
               <Typography variant="h5">Scope</Typography>
             </AccordionSummary>
@@ -95,7 +135,11 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.definitions}
+            onClick={() => handleClick("definitions")}
+          >
             <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
               <Typography variant="h5">Definitions</Typography>
             </AccordionSummary>
@@ -118,7 +162,11 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.agreement}
+            onClick={() => handleClick("agreement")}
+          >
             <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
               <Typography variant="h5">
                 Agreement to the terms and registering an account
@@ -163,7 +211,11 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.functions}
+            onClick={() => handleClick("functions")}
+          >
             <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
               <Typography variant="h5">Basic functions and rules of PostReview</Typography>
             </AccordionSummary>
@@ -231,7 +283,11 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.term}
+            onClick={() => handleClick("term")}
+          >
             <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
               <Typography variant="h5">Term and termination</Typography>
             </AccordionSummary>
@@ -250,7 +306,11 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.availability}
+            onClick={() => handleClick("availability")}
+          >
             <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
               <Typography variant="h5">Availability and maintenance</Typography>
             </AccordionSummary>
@@ -262,7 +322,11 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.data}
+            onClick={() => handleClick("data")}
+          >
             <AccordionSummary aria-controls="panel7d-content" id="panel7d-header">
               <Typography variant="h5">Protecting data</Typography>
             </AccordionSummary>
@@ -274,7 +338,11 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.change}
+            onClick={() => handleClick("change")}
+          >
             <AccordionSummary aria-controls="panel8d-content" id="panel8d-header">
               <Typography variant="h5">Changes to the terms</Typography>
             </AccordionSummary>
@@ -300,7 +368,11 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.law}
+            onClick={() => handleClick("law")}
+          >
             <AccordionSummary aria-controls="panel9d-content" id="panel9d-header">
               <Typography variant="h5">Governing law</Typography>
             </AccordionSummary>
@@ -313,7 +385,11 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.contact}
+            onClick={() => handleClick("contact")}
+          >
             <AccordionSummary aria-controls="panel10d-content" id="panel10d-header">
               <Typography variant="h5">Contact</Typography>
             </AccordionSummary>
@@ -332,7 +408,11 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion sx={{ ...accordionStyle }}>
+          <Accordion
+            sx={{ ...accordionStyle }}
+            expanded={accordion.acknowledgement}
+            onClick={() => handleClick("acknowledgement")}
+          >
             <AccordionSummary aria-controls="panel11d-content" id="panel11d-header">
               <Typography variant="h5">Acknowledgement</Typography>
             </AccordionSummary>


### PR DESCRIPTION
This PR adds expand and collapse for the accordion components on the following pages:

1. Terms of use
2. Privacy policy
3. Code of conduct 

Fixes #305. 