### PR TITLE
Move click events on the accordion to the accordion summary component (on policy pages)

### DIFF
--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -110,7 +110,6 @@ body {
   }
 }
 
-
 /* Animate the text on the about page */
 /*Vertical Sliding*/
 .slidingVertical {
@@ -174,7 +173,7 @@ body {
   100% {
     opacity: 0;
   }
-
+}
 
 /* Uploadcare Dialog Styling */
 .uploadcare--panel__content {

--- a/app/pages/about.tsx
+++ b/app/pages/about.tsx
@@ -48,25 +48,25 @@ const About: BlitzPage = () => {
             </h3>
           </div>
           <div id="words-container" className="mx-4 my-4 text-4xl font-bold">
-            <div className="my-4 animate-[pulse_4s_infinite] text-right hover:cursor-pointer hover:animate-bounce">
+            <div className="ml-auto w-min whitespace-nowrap my-4 animate-[pulse_4s_infinite] text-right hover:cursor-pointer hover:animate-bounce">
               a safe place
             </div>
-            <div className="my-6 animate-[pulse_8s_infinite] text-left hover:cursor-pointer hover:animate-bounce">
+            <div className="mr-auto w-min my-6 animate-[pulse_8s_infinite] text-left hover:cursor-pointer hover:animate-bounce">
               convenient
             </div>
-            <div className="my-6 text-center hover:cursor-pointer hover:animate-bounce text-black">
+            <div className="mx-auto w-min my-6 text-center hover:cursor-pointer hover:animate-bounce text-black">
               accessible
             </div>
-            <div className="my-4 animate-[pulse_10s_infinite] text-right hover:cursor-pointer hover:animate-bounce">
+            <div className="ml-auto w-min my-4 animate-[pulse_10s_infinite] text-right hover:cursor-pointer hover:animate-bounce">
               transparent
             </div>
-            <div className="my-4 animate-[pulse_4s_infinite] text-left hover:cursor-pointer hover:animate-bounce">
+            <div className="mr-auto w-min my-4 animate-[pulse_4s_infinite] text-left hover:cursor-pointer hover:animate-bounce">
               fun
             </div>
-            <div className="my-4 animate-[pulse_6s_infinite] text-center hover:cursor-pointer hover:animate-bounce">
+            <div className="mx-auto w-min my-4 animate-[pulse_6s_infinite] text-center hover:cursor-pointer hover:animate-bounce">
               equitable
             </div>
-            <div className="my-4 text-right hover:cursor-pointer hover:animate-bounce text-black">
+            <div className="ml-auto w-min my-4 text-right hover:cursor-pointer hover:animate-bounce text-black">
               open
             </div>
           </div>

--- a/app/pages/code-of-conduct.tsx
+++ b/app/pages/code-of-conduct.tsx
@@ -128,12 +128,12 @@ const CodeOfConductPage: BlitzPage = () => {
               {expandClicked ? "Collapse" : "Expand All"}
             </button>
           </div>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.standards}
-            onClick={() => handleClick("standards")}
-          >
-            <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.standards}>
+            <AccordionSummary
+              aria-controls="panel1d-content"
+              id="panel1d-header"
+              onClick={() => handleClick("standards")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Our Standards
               </Typography>
@@ -181,12 +181,12 @@ const CodeOfConductPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.responsibilities}
-            onClick={() => handleClick("responsibilities")}
-          >
-            <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.responsibilities}>
+            <AccordionSummary
+              aria-controls="panel2d-content"
+              id="panel2d-header"
+              onClick={() => handleClick("responsibilities")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Enforcement Responsibilities
               </Typography>
@@ -205,12 +205,12 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.scope}
-            onClick={() => handleClick("scope")}
-          >
-            <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.scope}>
+            <AccordionSummary
+              aria-controls="panel3d-content"
+              id="panel3d-header"
+              onClick={() => handleClick("scope")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Scope
               </Typography>
@@ -225,12 +225,12 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.enforcement}
-            onClick={() => handleClick("enforcement")}
-          >
-            <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.enforcement}>
+            <AccordionSummary
+              aria-controls="panel4d-content"
+              id="panel4d-header"
+              onClick={() => handleClick("enforcement")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Enforcement
               </Typography>
@@ -283,12 +283,12 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.guidelines}
-            onClick={() => handleClick("guidelines")}
-          >
-            <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.guidelines}>
+            <AccordionSummary
+              aria-controls="panel5d-content"
+              id="panel5d-header"
+              onClick={() => handleClick("guidelines")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Enforcement Guidelines
               </Typography>
@@ -356,12 +356,12 @@ const CodeOfConductPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.attribution}
-            onClick={() => handleClick("attribution")}
-          >
-            <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.attribution}>
+            <AccordionSummary
+              aria-controls="panel6d-content"
+              id="panel6d-header"
+              onClick={() => handleClick("attribution")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Attribution
               </Typography>

--- a/app/pages/privacy-policy.tsx
+++ b/app/pages/privacy-policy.tsx
@@ -140,12 +140,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
             </button>
           </div>
 
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.definitions}
-            onClick={() => handleClick("definitions")}
-          >
-            <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.definitions}>
+            <AccordionSummary
+              aria-controls="panel1d-content"
+              id="panel1d-header"
+              onClick={() => handleClick("definitions")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Definitions
               </Typography>
@@ -195,12 +195,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.personal}
-            onClick={() => handleClick("personal")}
-          >
-            <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.personal}>
+            <AccordionSummary
+              aria-controls="panel2d-content"
+              id="panel2d-header"
+              onClick={() => handleClick("personal")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Personal data
               </Typography>
@@ -213,12 +213,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.usage}
-            onClick={() => handleClick("usage")}
-          >
-            <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.usage}>
+            <AccordionSummary
+              aria-controls="panel3d-content"
+              id="panel3d-header"
+              onClick={() => handleClick("usage")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Usage data
               </Typography>
@@ -242,12 +242,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.cookies}
-            onClick={() => handleClick("cookies")}
-          >
-            <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.cookies}>
+            <AccordionSummary
+              aria-controls="panel4d-content"
+              id="panel4d-header"
+              onClick={() => handleClick("cookies")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Cookies
               </Typography>
@@ -274,12 +274,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.purposes}
-            onClick={() => handleClick("purposes")}
-          >
-            <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.purposes}>
+            <AccordionSummary
+              aria-controls="panel5d-content"
+              id="panel5d-header"
+              onClick={() => handleClick("purposes")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Purposes of processing your data
               </Typography>
@@ -320,12 +320,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.share}
-            onClick={() => handleClick("share")}
-          >
-            <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.share}>
+            <AccordionSummary
+              aria-controls="panel6d-content"
+              id="panel6d-header"
+              onClick={() => handleClick("share")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 We may share your personal information
               </Typography>
@@ -352,12 +352,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.retention}
-            onClick={() => handleClick("retention")}
-          >
-            <AccordionSummary aria-controls="panel7d-content" id="panel7d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.retention}>
+            <AccordionSummary
+              aria-controls="panel7d-content"
+              id="panel7d-header"
+              onClick={() => handleClick("retention")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Retention of your personal data
               </Typography>
@@ -380,12 +380,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.transfer}
-            onClick={() => handleClick("transfer")}
-          >
-            <AccordionSummary aria-controls="panel8d-content" id="panel8d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.transfer}>
+            <AccordionSummary
+              aria-controls="panel8d-content"
+              id="panel8d-header"
+              onClick={() => handleClick("transfer")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Transfer of your personal data
               </Typography>
@@ -425,12 +425,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.disclosure}
-            onClick={() => handleClick("disclosure")}
-          >
-            <AccordionSummary aria-controls="panel9d-content" id="panel9d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.disclosure}>
+            <AccordionSummary
+              aria-controls="panel9d-content"
+              id="panel9d-header"
+              onClick={() => handleClick("disclosure")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Disclosure of your personal data
               </Typography>
@@ -464,12 +464,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.security}
-            onClick={() => handleClick("security")}
-          >
-            <AccordionSummary aria-controls="panel10d-content" id="panel10d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.security}>
+            <AccordionSummary
+              aria-controls="panel10d-content"
+              id="panel10d-header"
+              onClick={() => handleClick("security")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Security of your personal data
               </Typography>
@@ -483,12 +483,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.changes}
-            onClick={() => handleClick("changes")}
-          >
-            <AccordionSummary aria-controls="panel11d-content" id="panel11d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.changes}>
+            <AccordionSummary
+              aria-controls="panel11d-content"
+              id="panel11d-header"
+              onClick={() => handleClick("changes")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Changes to this privacy policy
               </Typography>
@@ -507,12 +507,12 @@ const PrivacyPolicyPage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.contact}
-            onClick={() => handleClick("contact")}
-          >
-            <AccordionSummary aria-controls="panel12d-content" id="panel12d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.contact}>
+            <AccordionSummary
+              aria-controls="panel12d-content"
+              id="panel12d-header"
+              onClick={() => handleClick("contact")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Contact us
               </Typography>

--- a/app/pages/terms-of-use.tsx
+++ b/app/pages/terms-of-use.tsx
@@ -119,12 +119,12 @@ const TermsofUsePage: BlitzPage = () => {
             </button>
           </div>
 
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.scope}
-            onClick={() => handleClick("scope")}
-          >
-            <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.scope}>
+            <AccordionSummary
+              aria-controls="panel1d-content"
+              id="panel1d-header"
+              onClick={() => handleClick("scope")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Scope
               </Typography>
@@ -143,12 +143,12 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.definitions}
-            onClick={() => handleClick("definitions")}
-          >
-            <AccordionSummary aria-controls="panel2d-content" id="panel2d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.definitions}>
+            <AccordionSummary
+              aria-controls="panel2d-content"
+              id="panel2d-header"
+              onClick={() => handleClick("definitions")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Definitions
               </Typography>
@@ -172,12 +172,12 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.agreement}
-            onClick={() => handleClick("agreement")}
-          >
-            <AccordionSummary aria-controls="panel3d-content" id="panel3d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.agreement}>
+            <AccordionSummary
+              aria-controls="panel3d-content"
+              id="panel3d-header"
+              onClick={() => handleClick("agreement")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Agreement to the terms and registering an account
               </Typography>
@@ -221,12 +221,12 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.functions}
-            onClick={() => handleClick("functions")}
-          >
-            <AccordionSummary aria-controls="panel4d-content" id="panel4d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.functions}>
+            <AccordionSummary
+              aria-controls="panel4d-content"
+              id="panel4d-header"
+              onClick={() => handleClick("functions")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Basic functions and rules of PostReview
               </Typography>
@@ -295,12 +295,12 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.term}
-            onClick={() => handleClick("term")}
-          >
-            <AccordionSummary aria-controls="panel5d-content" id="panel5d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.term}>
+            <AccordionSummary
+              aria-controls="panel5d-content"
+              id="panel5d-header"
+              onClick={() => handleClick("term")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Term and termination
               </Typography>
@@ -320,12 +320,12 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.availability}
-            onClick={() => handleClick("availability")}
-          >
-            <AccordionSummary aria-controls="panel6d-content" id="panel6d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.availability}>
+            <AccordionSummary
+              aria-controls="panel6d-content"
+              id="panel6d-header"
+              onClick={() => handleClick("availability")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Availability and maintenance
               </Typography>
@@ -338,12 +338,12 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.data}
-            onClick={() => handleClick("data")}
-          >
-            <AccordionSummary aria-controls="panel7d-content" id="panel7d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.data}>
+            <AccordionSummary
+              aria-controls="panel7d-content"
+              id="panel7d-header"
+              onClick={() => handleClick("data")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Protecting data
               </Typography>
@@ -356,12 +356,12 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.change}
-            onClick={() => handleClick("change")}
-          >
-            <AccordionSummary aria-controls="panel8d-content" id="panel8d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.change}>
+            <AccordionSummary
+              aria-controls="panel8d-content"
+              id="panel8d-header"
+              onClick={() => handleClick("change")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Changes to the terms
               </Typography>
@@ -388,12 +388,12 @@ const TermsofUsePage: BlitzPage = () => {
               </ul>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.law}
-            onClick={() => handleClick("law")}
-          >
-            <AccordionSummary aria-controls="panel9d-content" id="panel9d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.law}>
+            <AccordionSummary
+              aria-controls="panel9d-content"
+              id="panel9d-header"
+              onClick={() => handleClick("law")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Governing law
               </Typography>
@@ -407,12 +407,12 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.contact}
-            onClick={() => handleClick("contact")}
-          >
-            <AccordionSummary aria-controls="panel10d-content" id="panel10d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.contact}>
+            <AccordionSummary
+              aria-controls="panel10d-content"
+              id="panel10d-header"
+              onClick={() => handleClick("contact")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Contact
               </Typography>
@@ -432,12 +432,12 @@ const TermsofUsePage: BlitzPage = () => {
               </p>
             </AccordionDetails>
           </Accordion>
-          <Accordion
-            sx={{ ...accordionStyle }}
-            expanded={accordion.acknowledgement}
-            onClick={() => handleClick("acknowledgement")}
-          >
-            <AccordionSummary aria-controls="panel11d-content" id="panel11d-header">
+          <Accordion sx={{ ...accordionStyle }} expanded={accordion.acknowledgement}>
+            <AccordionSummary
+              aria-controls="panel11d-content"
+              id="panel11d-header"
+              onClick={() => handleClick("acknowledgement")}
+            >
               <Typography variant="h5" fontWeight="bold">
                 Acknowledgement
               </Typography>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,23 @@ module.exports = {
   content: ["{pages,app}/**/*.{js,ts,jsx,tsx}"],
   darkMode: "media", // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      animation: {
+        bounce: "bounce 1s infinite",
+      },
+      keyframes: {
+        bounce: {
+          "0%, 100%": {
+            transform: "translateY(0%)",
+            "animation-timing-function": "cubic-bezier(0, 0, 0.2, 1)",
+          },
+          "50%": {
+            transform: "translateY(-25%)",
+            "animation-timing-function": "cubic-bezier(0.8, 0, 1, 1)",
+          },
+        },
+      },
+    },
     fontFamily: {
       sans: ['"Fira Sans"', "sans-serif"],
     },


### PR DESCRIPTION
This PR moves the click events of the accordions to the accordion summary component, instead of the whole accordion component. 

Fixes #342. 