### PR TITLE
Add tooltips for the navigation dots

### DIFF
--- a/app/core/components/NavDots.tsx
+++ b/app/core/components/NavDots.tsx
@@ -1,23 +1,41 @@
 import { Tooltip } from "@mui/material"
-import React from "react"
-
-const Dot = (props) => {
-  return (
-    <Tooltip title={props.category} placement="top">
-      <div
-        {...props}
-        className={`${props.selected ? "w-5 h-5" : "w-3 h-3"}\
-   ${props.category === "Overall" ? "bg-green" : "bg-white"} rounded-full \
-    hover:cursor-pointer \
-    transition-all
-    `}
-      ></div>
-    </Tooltip>
-  )
-}
+import React, { useState } from "react"
 
 export const NavDots = (props) => {
   const { searchCategories, setQuestionCategory, questionCategory } = props
+
+  // Create an object of search categories where everything is false
+  const defaultTooltips = searchCategories.reduce((acc, elem) => {
+    acc[elem] = false
+    return acc
+  }, {})
+
+  const [clicks, setClicks] = useState(defaultTooltips)
+
+  const handleClick = (category) => {
+    setQuestionCategory(category)
+    setClicks({ ...defaultTooltips, [category]: true })
+  }
+
+  const Dot = (props) => {
+    return (
+      <Tooltip
+        title={props.category}
+        placement="top"
+        open={clicks[props.category]}
+        onClose={() => setClicks(defaultTooltips)}
+      >
+        <div
+          {...props}
+          className={`${props.selected ? "w-5 h-5" : "w-3 h-3"}\
+     ${props.category === "Overall" ? "bg-green" : "bg-white"} rounded-full \
+      hover:cursor-pointer \
+      transition-all
+      `}
+        ></div>
+      </Tooltip>
+    )
+  }
 
   return (
     <div id="dot-area" className="mx-auto w-72 fixed inset-x-0 bottom-16">
@@ -28,7 +46,7 @@ export const NavDots = (props) => {
         {searchCategories.map((category) => (
           <Dot
             key={category}
-            onClick={() => setQuestionCategory(category)}
+            onClick={() => handleClick(category)}
             selected={category === questionCategory}
             category={category}
           />

--- a/app/core/components/NavDots.tsx
+++ b/app/core/components/NavDots.tsx
@@ -1,15 +1,18 @@
+import { Tooltip } from "@mui/material"
 import React from "react"
 
 const Dot = (props) => {
   return (
-    <div
-      {...props}
-      className={`${props.selected ? "w-5 h-5" : "w-3 h-3"}\
+    <Tooltip title={props.category} placement="top">
+      <div
+        {...props}
+        className={`${props.selected ? "w-5 h-5" : "w-3 h-3"}\
    ${props.category === "Overall" ? "bg-green" : "bg-white"} rounded-full \
     hover:cursor-pointer \
     transition-all
     `}
-    ></div>
+      ></div>
+    </Tooltip>
   )
 }
 


### PR DESCRIPTION
This PR adds tooltips for the navigation dots. Fixes #304.

![image](https://user-images.githubusercontent.com/17035406/187049124-86a8ae42-f1f6-4ccf-97ff-f814020f783b.png)
 