### PR TITLE
Change the styling for the error message on log-in page

### DIFF
--- a/app/auth/pages/login.tsx
+++ b/app/auth/pages/login.tsx
@@ -77,7 +77,7 @@ const LoginPage: BlitzPage = () => {
             }) => (
               <form onSubmit={handleSubmit} className="flex flex-col w-full">
                 {showError && (
-                  <div className="bg-red-500 bg-opacity-50 rounded-md text-center p-3">
+                  <div className="bg-black/60 rounded-md text-red text-center p-2">
                     Incorrect email or password
                   </div>
                 )}


### PR DESCRIPTION
This PR changes the styling for the error message on the log-in page for better visibility.

Fixes #349

Before:
![localhost_3000_login(iPhone XR) (6)](https://user-images.githubusercontent.com/42837484/187053398-84f2828c-dc76-47a1-ae5a-bd22ebfe6aa3.png)
![localhost_3000_login(iPhone XR) (5)](https://user-images.githubusercontent.com/42837484/187053417-1389be8a-fd6a-43d0-93a9-41da42c67c2f.png)


After:
![localhost_3000_(iPhone XR) (15)](https://user-images.githubusercontent.com/42837484/187053443-ea774512-a574-4b4e-a808-843b247cbc11.png)
![localhost_3000_login(iPhone XR) (4)](https://user-images.githubusercontent.com/42837484/187053445-a37d7c81-a54b-48db-9e22-36f202af1531.png)

