### PR TITLE
Adjust the margins for no reviews state on the public profile

### DIFF
--- a/app/core/components/MyReviewsEmptyState.tsx
+++ b/app/core/components/MyReviewsEmptyState.tsx
@@ -6,7 +6,7 @@ export const MyReviewsEmptyState = () => {
     <div>
       <div
         className="m-6 p-4 border-gray-medium border-2 border-dashed
-    flex flex-col  max-w-5xl h-32 justify-center"
+    flex flex-col max-w-5xl h-32 justify-center"
       >
         <div className="flex flex-col items-center">
           <div

--- a/app/pages/profiles/[handle].tsx
+++ b/app/pages/profiles/[handle].tsx
@@ -26,8 +26,8 @@ const PublicProfileDetails = () => {
         <ProfileBgImage />
         <ProfileInfo userInfo={userInfo} showEditButton={false} />
 
-        <div id="my-reviews-container" className="m-4 mt-8 max-w-2xl">
-          <h1 className="ml-8 text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
+        <div id="my-reviews-container" className="mt-8 max-w-7xl">
+          <h1 className="text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
           <div className="text-gray-darkest dark:text-white">
             {defaultArticlesWithReview.length === 0 && (
               <div


### PR DESCRIPTION
This PR changes the positioning of components for "no reviews state" on the public profile.

Fixes #358 

![image](https://user-images.githubusercontent.com/42837484/187108542-bdcc7a6b-7ea6-42ac-b603-f6a693504363.png)
