### PR TITLE
Fix Google Auth email verification failing

### DIFF
--- a/app/api/auth/[...auth].ts
+++ b/app/api/auth/[...auth].ts
@@ -27,7 +27,8 @@ export default passportAuth({
             where: { email },
             create: {
               email,
-              handle: profile.displayName,
+              // Remove any whitespaces from the display name and make it a handle
+              handle: profile.displayName.replace(/ /g, ""),
               displayName: profile.displayName,
               icon: profile.photos[0]?.value,
             },

--- a/app/api/auth/[...auth].ts
+++ b/app/api/auth/[...auth].ts
@@ -5,7 +5,7 @@ import { Strategy as GoogleStrategy } from "passport-google-oauth20"
 
 export default passportAuth({
   // TODO: If success, pass the email, icon, displayname to the success redirectURL?
-  successRedirectUrl: "/",
+  successRedirectUrl: "/signup",
   errorRedirectUrl: "/",
   strategies: [
     {

--- a/app/api/auth/[...auth].ts
+++ b/app/api/auth/[...auth].ts
@@ -31,6 +31,8 @@ export default passportAuth({
               handle: profile.displayName.replace(/ /g, ""),
               displayName: profile.displayName,
               icon: profile.photos[0]?.value,
+              // Assume Google Email is verified
+              emailIsVerified: true,
             },
             update: { email },
           })


### PR DESCRIPTION
This PR fixes a bug where clicking the resend email button for users with Google Auth will throw an error, and potentially freeze up the app.

This PR marks the user's email as verified when using Google Auth.

This PR also includes a fix where Google Auth users may have invalid handles with white spaces. Now, their handles will be their display name without white spaces. 

Fixes #367. 