### PR TITLE
Optimize the search bar responsiveness

### DIFF
--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -34,6 +34,21 @@ export default function EnterDOI(props) {
     router.push(`/articles/${addedArticle.id}`)
   }
 
+  // Prepare debounce to wait before querying CrossRef
+  function debouncePromise(fn, time) {
+    let timerId = undefined
+    return function debounced(...args) {
+      if (timerId) {
+        clearTimeout(timerId)
+      }
+
+      return new Promise((resolve) => {
+        timerId = setTimeout(() => resolve(fn(...args)), time) as any
+      })
+    }
+  }
+  const debounced = debouncePromise((items) => Promise.resolve(items), 300)
+
   return (
     <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">
       <Autocomplete
@@ -76,7 +91,7 @@ export default function EnterDOI(props) {
           )
             .then((response) => response.json())
             .then(({ message }) => {
-              return [
+              return debounced([
                 {
                   // Look for papers already in our database
                   sourceId: "products",
@@ -130,7 +145,7 @@ export default function EnterDOI(props) {
                     },
                   },
                 },
-              ]
+              ])
             })
         }}
       />

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -87,7 +87,7 @@ export default function EnterDOI(props) {
           return fetch(
             `https://api.crossref.org/works/?query=${encodeURIComponent(
               query
-            )}&select=title,author,published,DOI&rows=5`
+            )}&select=title,author,published,DOI&rows=10`
           )
             .then((response) => response.json())
             .then(({ message }) => {

--- a/app/core/components/SearchResultArticle.tsx
+++ b/app/core/components/SearchResultArticle.tsx
@@ -2,7 +2,7 @@ const SearchResultArticle = ({ item, components }) => {
   return (
     <>
       <div className="my-1 mx-1 flex-col">
-        <div className="mr-2">{item.title}</div>
+        <div className="mr-2">{item.title || item.name}</div>
         <div>
           <p className="text-xs text-gray-500 dark:text-gray-400">
             {item?.authors} {item.publishedYear && `(${item.publishedYear})`}


### PR DESCRIPTION
This PR optimizes the response of the search bar by adding a wait before querying CrossRef, instead of querying CorssRef every keystroke. Fixes #372.

