### PR TITLE
Add a cookies confirmation dialogue

### DIFF
--- a/app/core/components/CookieConsentModal.tsx
+++ b/app/core/components/CookieConsentModal.tsx
@@ -1,0 +1,49 @@
+import { Link, Routes } from "blitz"
+import React from "react"
+import CookieConsent from "react-cookie-consent"
+
+export const CookieConsentModal = (props) => {
+  const { setCookieAccepted } = props
+  return (
+    <>
+      <CookieConsent
+        location="bottom"
+        style={{
+          borderTop: "2px solid gray",
+          left: "50",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+        buttonText="Accept"
+        declineButtonText="Decline"
+        cookieName="postreview-cookies"
+        buttonStyle={{
+          backgroundColor: "#545454",
+          color: "#94EC01",
+          fontSize: "1rem",
+        }}
+        declineButtonStyle={{
+          backgroundColor: "#545454",
+          color: "#fff",
+          fontSize: "1rem",
+        }}
+        expires={150}
+        onAccept={() => {
+          setCookieAccepted(true)
+        }}
+        enableDeclineButton
+      >
+        We use cookies! Some are necessary, but some are optional. Why do we use them? For analyzing
+        site usage, enhancing site navigation, and improving our service. If you decline, you may
+        still see some cookies, but they will be fully anonymized. See also our{" "}
+        <Link href={Routes.PrivacyPolicyPage()}>
+          <a className="underline hover:text-white hover:no-underline" target="_blank">
+            Privacy policy
+          </a>
+        </Link>
+      </CookieConsent>
+    </>
+  )
+}

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -1,6 +1,8 @@
-import { ReactNode } from "react"
+import { ReactNode, useEffect, useState } from "react"
 import { Head } from "blitz"
 import LayoutLoader from "../components/LayoutLoader"
+import { getCookieConsentValue } from "react-cookie-consent"
+import { CookieConsentModal } from "../components/CookieConsentModal"
 
 type LayoutProps = {
   title?: string
@@ -8,14 +10,26 @@ type LayoutProps = {
 }
 
 const Layout = ({ title, children }: LayoutProps) => {
+  const [cookie, setCookie] = useState(() => <></>)
+  const [cookieAccepted, setCookieAccepted] = useState(
+    getCookieConsentValue("postreview-cookies") === "true"
+  )
+  useEffect(() => {
+    if (cookieAccepted) {
+      setCookie(<script type="text/javascript">{undefined}</script>)
+    }
+  }, [cookieAccepted])
+
   return (
     <>
       <Head>
         <title>{title || "PostReview"}</title>
         <link rel="icon" href="/favicon.ico" />
         <script data-respect-dnt data-no-cookie async src="https://cdn.splitbee.io/sb.js"></script>
+        {cookie}
       </Head>
       <LayoutLoader>{children}</LayoutLoader>
+      <CookieConsentModal setCookieAccepted={setCookieAccepted} />
     </>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "postmark": "3.0.1",
         "prisma": "3.12.0",
         "react": "18.0.0-alpha-67222f044-20210915",
+        "react-cookie-consent": "8.0.1",
         "react-dom": "18.0.0-alpha-67222f044-20210915",
         "react-final-form": "6.5.3",
         "react-icons": "4.2.0",
@@ -10897,6 +10898,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -14602,6 +14608,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie-consent": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-8.0.1.tgz",
+      "integrity": "sha512-4A2jzPQDFfBhtxIz4hYX+vJ0QnOknGdOXpEoetXzgwUrMtxVJVow8YgBsGerNt5rJI7WhKkHwr8LmxekxgVejg==",
+      "dependencies": {
+        "js-cookie": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/react-devtools-core": {
@@ -26717,6 +26737,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -29571,6 +29596,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-cookie-consent": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-8.0.1.tgz",
+      "integrity": "sha512-4A2jzPQDFfBhtxIz4hYX+vJ0QnOknGdOXpEoetXzgwUrMtxVJVow8YgBsGerNt5rJI7WhKkHwr8LmxekxgVejg==",
+      "requires": {
+        "js-cookie": "^2.2.1"
       }
     },
     "react-devtools-core": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "postmark": "3.0.1",
     "prisma": "3.12.0",
     "react": "18.0.0-alpha-67222f044-20210915",
+    "react-cookie-consent": "8.0.1",
     "react-dom": "18.0.0-alpha-67222f044-20210915",
     "react-final-form": "6.5.3",
     "react-icons": "4.2.0",


### PR DESCRIPTION
This PR adds a cookies-confirmation dialogue to the app. Fixes #335. 

I was not able to implement the original design for the mobile for now, since the `react-cookie-consent` only allows positioning the dialogue on the top or bottom of the page. 