### PR TITLE
Optimize the search bar performance by increasing debounce and disabling open-on-focus

### DIFF
--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -47,7 +47,7 @@ export default function EnterDOI(props) {
       })
     }
   }
-  const debounced = debouncePromise((items) => Promise.resolve(items), 300)
+  const debounced = debouncePromise((items) => Promise.resolve(items), 100)
 
   return (
     <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">
@@ -84,7 +84,7 @@ export default function EnterDOI(props) {
               })
           }
           // If the input is not a DOI, query the CrossRef endpoint
-          return debounced([
+          return [
             {
               // Look for papers already in our database
               sourceId: "products",

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -47,7 +47,7 @@ export default function EnterDOI(props) {
       })
     }
   }
-  const debounced = debouncePromise((items) => Promise.resolve(items), 1000)
+  const debounced = debouncePromise((items) => Promise.resolve(items), 300)
 
   return (
     <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -120,22 +120,24 @@ export default function EnterDOI(props) {
                 handleArticleAdd(currentItem)
               },
               getItems() {
-                return fetch(
-                  `https://api.crossref.org/works/?query=${encodeURIComponent(
-                    query
-                  )}&select=title,author,published,DOI&rows=10`
+                return debounced(
+                  fetch(
+                    `https://api.crossref.org/works/?query=${encodeURIComponent(
+                      query
+                    )}&select=title,author,published,DOI&rows=10`
+                  )
+                    .then((response) => response.json())
+                    .then(({ message }) => {
+                      // Filter out items
+                      const filteredItems = message.items
+                        // filter out items without titles (Ex. "vegetab" returning items without titles)
+                        .filter((item) => item.title)
+                        // filter out items without published dates
+                        .filter((item) => item.published?.["date-parts"])
+                      return filteredItems
+                    })
+                    .catch(() => [])
                 )
-                  .then((response) => response.json())
-                  .then(({ message }) => {
-                    // Filter out items
-                    const filteredItems = message.items
-                      // filter out items without titles (Ex. "vegetab" returning items without titles)
-                      .filter((item) => item.title)
-                      // filter out items without published dates
-                      .filter((item) => item.published?.["date-parts"])
-                    return filteredItems
-                  })
-                  .catch(() => [])
               },
               getItemInputValue({ item }) {
                 return item.description
@@ -147,7 +149,7 @@ export default function EnterDOI(props) {
                 },
               },
             },
-          ])
+          ]
         }}
       />
     </div>

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -53,7 +53,7 @@ export default function EnterDOI(props) {
     <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">
       <Autocomplete
         placeholder="Search Title, Author, DOI"
-        openOnFocus={true}
+        openOnFocus={false}
         getSources={({ query }) => {
           // If the input is a DOI, return the specific paper
           // `https://api.crossref.org/works/${matchedDOI}`

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -47,7 +47,7 @@ export default function EnterDOI(props) {
       })
     }
   }
-  const debounced = debouncePromise((items) => Promise.resolve(items), 300)
+  const debounced = debouncePromise((items) => Promise.resolve(items), 1000)
 
   return (
     <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">


### PR DESCRIPTION
This PR sets debounce to one second. Fixes #375.
