### PR TITLE
Avoid showing the "No 1" thank-you badge for edits, and at all for reviews with all-null answers

### DIFF
--- a/app/core/components/ArticleAction.tsx
+++ b/app/core/components/ArticleAction.tsx
@@ -17,7 +17,7 @@ import changeReviewAnonimity from "app/mutations/changeReivewAnonimity"
 import { MoreHoriz } from "@mui/icons-material"
 
 export const ArticleAction = (props) => {
-  const { article } = props
+  const { article, articleHasReview } = props
   const session = useSession()
   const router = useRouter()
   const [anchorEl, setAnchorEl] = useState(null)
@@ -93,6 +93,7 @@ export const ArticleAction = (props) => {
           setUserHasReview={setUserHasReview}
           setIsChangeMade={setIsChangeMade}
           session={session}
+          articleHasReview={articleHasReview}
         />
       </Dialog>
       <Box>

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -87,7 +87,10 @@ export default function PopupReview(prop) {
 
   const handleReviewSubmit = async () => {
     setLoading(true)
-    showThankYou()
+    // Thank-you badge
+    // Check if all answers are null
+    const reviewsAllNull = reviewAnswers.map((answer) => answer.response).every((e) => e === null)
+    if (!reviewsAllNull) showThankYou()
     // If there's no rating given, show the error message
     if (reviewAnswers.length == 0) return setShowReviewRequiredError(true)
     await invoke(addReviewMutation, reviewAnswers)

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -18,6 +18,7 @@ export const Review = (props) => {
     ratingScaleMax,
     showArticleAction = false,
     article,
+    articleHasReview,
   } = props
   const submittedAt = reviews[0]?.createdAt?.toISOString().split("T")[0]
   const updatedAt = reviews[0]?.updatedAt.toISOString().split("T")[0]
@@ -72,7 +73,7 @@ export const Review = (props) => {
       >
         {showArticleAction && (
           <div className="absolute top-0 right-0">
-            <ArticleAction article={article} />
+            <ArticleAction article={article} articleHasReview={articleHasReview} />
           </div>
         )}
         <div id="review-header-section" className="flex flex-row items-center relative">

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -5,7 +5,7 @@ import { Review } from "./Review"
 import getQuestionCategories from "app/queries/getQuestionCategories"
 
 export const ReviewList = (prop) => {
-  const { article, ratingScaleMax, session } = prop
+  const { article, ratingScaleMax, session, articleHasReview } = prop
 
   const [usersWithReview] = useQuery(getUsersWithReviewsByArticleId, {
     currentArticleId: article?.id,
@@ -38,6 +38,7 @@ export const ReviewList = (prop) => {
                 ratingScaleMax={ratingScaleMax}
                 showArticleAction={true}
                 article={{ ...article, review: { ...currentUserReview?.review } }}
+                articleHasReview={articleHasReview}
               />
             </div>
           </div>

--- a/app/pages/articles/[articleId].tsx
+++ b/app/pages/articles/[articleId].tsx
@@ -116,7 +116,12 @@ const ArticleDetails = (props) => {
           </div>
         )}
         {articleHasReview && (
-          <ReviewList article={article} ratingScaleMax={ratingScaleMax} session={session} />
+          <ReviewList
+            article={article}
+            ratingScaleMax={ratingScaleMax}
+            session={session}
+            articleHasReview={articleHasReview}
+          />
         )}
         <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
           <PopupReview


### PR DESCRIPTION
This PR fixes the following bugs:

1. A bug where users editing their reviews see "No 1" badge
2. A bug where users submitting all-null answers will see the "Thank-you" badge

Fixes #368. 