### PR TITLE
Fix skinny article container on profile

### DIFF
--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -16,7 +16,7 @@ export const MyReviewsTable = (props) => {
         return (
           <div
             key={article.id}
-            className="m-1 p-2 border-gray-medium/20 border-4
+            className="mx-2 my-4 p-2 border-gray-medium/20 border-4
             flex flex-col max-w-5xl"
           >
             <div id="metadata-container" className="flex flex-row justify-between items-center">

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -91,9 +91,9 @@ const Profile = () => {
         setOpen={setOpen}
         showEditButton={true}
       />
-      <div id="my-reviews-container" className="m-4 mt-8 max-w-2xl">
-        <h1 className="text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
-        <div className=" text-gray-darkest dark:text-white">
+      <div id="my-reviews-container" className="mx-4 mt-8 max-w-5xl">
+        <h1 className=" mx-2 text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
+        <div className=" text-gray-darkest dark:text-white w-96 sm:w-[40rem]">
           {myArticlesWithReview?.length === 0 && <MyReviewsEmptyState />}
           <MyReviewsTable articleWithReview={myArticlesWithReview} currentUser={currentUser} />
         </div>

--- a/app/pages/profiles/[handle].tsx
+++ b/app/pages/profiles/[handle].tsx
@@ -26,13 +26,13 @@ const PublicProfileDetails = () => {
         <ProfileBgImage />
         <ProfileInfo userInfo={userInfo} showEditButton={false} />
 
-        <div id="my-reviews-container" className="mt-8 max-w-7xl">
-          <h1 className="text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
-          <div className="text-gray-darkest dark:text-white">
+        <div id="my-reviews-container" className="mx-4 mt-8 max-w-5xl">
+          <h1 className="mx-2 text-2xl font-semibold text-gray-darkest dark:text-white">Reviews</h1>
+          <div className="text-gray-darkest dark:text-white w-96 sm:w-[40rem]">
             {defaultArticlesWithReview.length === 0 && (
               <div
                 className="m-6 p-4 border-gray-medium
-    flex flex-col w-80 h-32 justify-center"
+    flex flex-col w-96 sm:w-[40rem] h-32 justify-center"
               >
                 <div className="flex flex-col items-center">
                   <div


### PR DESCRIPTION
This PR adds a fixed width for review containers on the public and private profile pages. 

Fixes #369 

![image](https://user-images.githubusercontent.com/42837484/187565627-18d56c35-9cd3-4545-a523-5bbaadede515.png)
 