### PR TITLE
Change the font color for copyright

### DIFF
--- a/app/core/components/DrawerMenu.tsx
+++ b/app/core/components/DrawerMenu.tsx
@@ -151,7 +151,10 @@ export const DrawerMenu = (props) => {
               Sign up
             </button>
           </div>
-          <div id="copyright" className="self-end mx-4 mt-10 text-xl bg-gray-light text-black/90">
+          <div
+            id="copyright"
+            className="self-end mx-4 mt-10 text-lg bg-gray-light text-gray-medium/60"
+          >
             <span className="text-2xl">&copy;</span> PostReview {datetime.getFullYear()}
           </div>
         </div>


### PR DESCRIPTION
This PR changes the color of the copyright on the drawer menu.

Fixes #388 

![localhost_3000_(iPhone XR) (2)](https://user-images.githubusercontent.com/42837484/187573629-5421ee49-d495-4838-aefc-160d51d4ee94.png)
