### PR TITLE
Use an env var for Google Callback URL

### DIFF
--- a/app/api/auth/[...auth].ts
+++ b/app/api/auth/[...auth].ts
@@ -18,11 +18,7 @@ export default passportAuth({
         {
           clientID: process.env.GOOGLE_CLIENT_ID as string,
           clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-          callbackURL:
-            process.env.NODE_ENV === "production"
-              ? // deployment target
-                "https://postreview-app.herokuapp.com/api/auth/google/callback"
-              : process.env.GOOGLE_CALLBACK_URL,
+          callbackURL: process.env.GOOGLE_CALLBACK_URL,
           scope: ["email", "profile"],
         },
         // TODO: Ask users to set their own handle,


### PR DESCRIPTION
This PR changes the callback URL for the Google OAuth from a hard-coded string to the `GOOGLE_CALLBACK_URL`. Fixes #399.