### PR TITLE
Use `AvatarIcon` component in search results

### DIFF
--- a/app/core/components/SearchResultUser.tsx
+++ b/app/core/components/SearchResultUser.tsx
@@ -1,11 +1,16 @@
 import { Image } from "blitz"
+import { AvatarIcon } from "./AvatarIcon"
 
 const SearchResultUser = ({ item, components }) => {
   return (
     <>
       <div className="my-1 mx-1 flex flex-row">
         <div id="avatar">
-          <Image src={item.icon} alt="avatar icon" width={30} height={30} />
+          <AvatarIcon
+            currentUser={{ handle: item?.handle, icon: item?.icon, displayName: item?.displayName }}
+            width={30}
+            height={30}
+          />
         </div>
         <div id="user-metadata" className="flex flex-col ml-3">
           <div>{item?.displayName}</div>


### PR DESCRIPTION
This PR fixes the issue of failing search (TypeError) by using the `AvatarIcon` component in search result hits. Fixes #401. 