### PR TITLE
Revise Splitbee events for the Google OAuth and deactivating account

### DIFF
--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -265,7 +265,7 @@ const SignupPage: BlitzPage = () => {
             )}
           </Formik>
           <div className="text-gray-darkest dark:text-white text-bold text-center my-4">or</div>
-          <GoogleButton type="sign-up" data-splitbee-event="Sign up" />
+          <GoogleButton type="sign-up" />
           <div className="my-4 text-gray-darkest dark:text-white">
             Already have an account?{" "}
             <Link href={Routes.LoginPage()}>

--- a/app/core/components/GoogleButton.tsx
+++ b/app/core/components/GoogleButton.tsx
@@ -3,16 +3,15 @@ import { Image } from "blitz"
 import googleLogoSignIn from "public/google-custom-sign-in.png"
 import googleLogoSignUp from "public/google-custom-sign-up.png"
 
-
 export default function GoogleButton(props = { type: "sign-in" }) {
-
   const { type } = props
 
-  const googleLogo = type === "sign-in" ? googleLogoSignIn : type === "sign-up" ? googleLogoSignUp : googleLogoSignIn
+  const googleLogo =
+    type === "sign-in" ? googleLogoSignIn : type === "sign-up" ? googleLogoSignUp : googleLogoSignIn
 
   return (
     <>
-      <a href="/api/auth/google">
+      <a href="/api/auth/google" data-splitbee-event={type === "sign-up" ? "Sign up" : "Sign in"}>
         <Image src={googleLogo} alt="Sign-in with Google" height={106 / 2} width={374 / 2} />
       </a>
     </>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -111,6 +111,7 @@ const Profile = () => {
           className="m-2 font-semibold underline hover:cursor-pointer hover:text-gray-darkest text-gray-medium"
           onClick={() => setIsDeactivateAccountDialogOpen(true)}
           color="error"
+          data-splitbee-event={"Deactivate opened"}
         >
           Deactivate your account
         </Button>
@@ -125,10 +126,18 @@ const Profile = () => {
               you posted.
             </DialogContent>
             <DialogActions>
-              <Button type="cancel" onClick={() => setIsDeactivateAccountDialogOpen(false)}>
+              <Button
+                type="cancel"
+                onClick={() => setIsDeactivateAccountDialogOpen(false)}
+                data-splitbee-event={"Deactivate canceled"}
+              >
                 Cancel
               </Button>
-              <Button type="error" onClick={handleDeleteUser}>
+              <Button
+                type="error"
+                onClick={handleDeleteUser}
+                data-splitbee-event={"Deactivate completed"}
+              >
                 Deactivate
               </Button>
             </DialogActions>


### PR DESCRIPTION
This PR revises the Splitbee events for the Google OAuth, such that the events are now attached to the `<a>` tag.

This PR also adds Splitbee events for the deactivate account buttons. 