### PR TITLE
Add the `mailto` field to CrossRef Query

### DIFF
--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -144,7 +144,7 @@ export default function EnterDOI(props) {
               getItems() {
                 return debounced(
                   fetch(
-                    `https://api.crossref.org/works?query=${encodeURIComponent(
+                    `https://api.crossref.org/works?query.bibliographic=${encodeURIComponent(
                       query
                     )}&select=title,author,published,DOI&rows=10&mailto=info@postreview.org`
                   )

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -51,7 +51,7 @@ export default function EnterDOI(props) {
   const debounced = debouncePromise((items) => Promise.resolve(items), 100)
 
   return (
-    <div className="m-1 rounded-md flex flex-row items-center flex-grow max-w-7xl justify-end">
+    <div className="m-1 flex max-w-7xl flex-grow flex-row items-center justify-end rounded-md">
       <Autocomplete
         placeholder="Search Title, Author, DOI"
         openOnFocus={false}

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -61,7 +61,11 @@ export default function EnterDOI(props) {
           const matchedDOI = query?.match(/10.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i)
 
           if (matchedDOI) {
-            return fetch(`https://api.crossref.org/works/${encodeURIComponent(matchedDOI)}`)
+            return fetch(
+              `https://api.crossref.org/works/${encodeURIComponent(
+                matchedDOI
+              )}&mailto=info@postreview.org`
+            )
               .then((response) => response.json())
               .then(({ message }) => {
                 return [
@@ -140,9 +144,9 @@ export default function EnterDOI(props) {
               getItems() {
                 return debounced(
                   fetch(
-                    `https://api.crossref.org/works/?query=${encodeURIComponent(
+                    `https://api.crossref.org/works?query=${encodeURIComponent(
                       query
-                    )}&select=title,author,published,DOI&rows=10`
+                    )}&select=title,author,published,DOI&rows=10&mailto=info@postreview.org`
                   )
                     .then((response) => response.json())
                     .then(({ message }) => {


### PR DESCRIPTION
This PR add `mailto` field to the CrossRef query, to follow the recommendation by Crossref. I referred to [Tips for using the Crossref REST API](https://www.crossref.org/documentation/retrieve-metadata/rest-api/tips-for-using-the-crossref-rest-api/)

I was hoping that the speed of return query increases, which did not. Nevertheless, it's good to follow their recommendation. 

Fixes #416 